### PR TITLE
Add additional metrics with only Queue dimension

### DIFF
--- a/backend/cloudwatch.go
+++ b/backend/cloudwatch.go
@@ -68,8 +68,15 @@ func (cb *CloudWatchBackend) Collect(r *collector.Result) error {
 			})
 		}
 
+		// Add the queue first
 		dimensions = append(dimensions,
 			&cloudwatch.Dimension{Name: aws.String("Queue"), Value: aws.String(name)},
+		)
+
+		metrics = append(metrics, cloudwatchMetrics(c, dimensions)...)
+
+		// Then the queue + the org
+		dimensions = append(dimensions,
 			&cloudwatch.Dimension{Name: aws.String("Org"), Value: aws.String(r.Org)},
 		)
 


### PR DESCRIPTION
Ugh, I've misunderstood how Cloudwatch metrics work. All dimensions submitted must be matched on, so we can't submit a data point with a Org and a Queue dimension and then only match on the Queue dimension. 

This adds two data points, one with the Queue dimension and the other with Queue+Org. 

Without this change, the Elastic Stack would have to add back the OrgSlug as a mandatory param. 