### PR TITLE
Read AWS_REGION for cloudwatch, default to us-east-1

### DIFF
--- a/backend/cloudwatch.go
+++ b/backend/cloudwatch.go
@@ -61,7 +61,6 @@ func (cb *CloudWatchBackend) Collect(r *collector.Result) error {
 	}
 
 	svc := cloudwatch.New(sess)
-]
 	for _, d := range cb.dimensions {
 		log.Printf("Using custom Cloudwatch dimension of [ %s = %s ]", d.Key, d.Value)
 	}

--- a/backend/cloudwatch.go
+++ b/backend/cloudwatch.go
@@ -40,17 +40,28 @@ func ParseCloudWatchDimensions(ds string) ([]CloudWatchDimension, error) {
 
 // CloudWatchBackend sends metrics to AWS CloudWatch
 type CloudWatchBackend struct {
+	region     string
 	dimensions []CloudWatchDimension
 }
 
 // NewCloudWatchBackend returns a new CloudWatchBackend with optional dimensions
-func NewCloudWatchBackend(dimensions []CloudWatchDimension) *CloudWatchBackend {
-	return &CloudWatchBackend{dimensions: dimensions}
+func NewCloudWatchBackend(region string, dimensions []CloudWatchDimension) *CloudWatchBackend {
+	return &CloudWatchBackend{
+		region:     region,
+		dimensions: dimensions,
+	}
 }
 
 func (cb *CloudWatchBackend) Collect(r *collector.Result) error {
-	svc := cloudwatch.New(session.New())
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String(cb.region),
+	})
+	if err != nil {
+		return err
+	}
 
+	svc := cloudwatch.New(sess)
+]
 	for _, d := range cb.dimensions {
 		log.Printf("Using custom Cloudwatch dimension of [ %s = %s ]", d.Key, d.Value)
 	}

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -33,6 +33,7 @@ func main() {
 
 func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 	token := os.Getenv("BUILDKITE_AGENT_TOKEN")
+	awsRegion := os.Getenv("AWS_REGION")
 	ssmTokenKey := os.Getenv("BUILDKITE_AGENT_TOKEN_SSM_KEY")
 	backendOpt := os.Getenv("BUILDKITE_BACKEND")
 	queue := os.Getenv("BUILDKITE_QUEUE")
@@ -82,7 +83,7 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		b = backend.NewCloudWatchBackend(dimensions)
+		b = backend.NewCloudWatchBackend(awsRegion, dimensions)
 	}
 
 	res, err := c.Collect()


### PR DESCRIPTION
Metrics don't use a particular region, so this adds a default. 

Closes #44.