### PR TITLE
Drop metrics with only queue dimension

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,19 +97,19 @@ Currently this will publish metrics to Cloudwatch under the custom metric prefix
 The following metrics are gathered when no specific queue is supplied:
 
 ```
-Buildkite > RunningJobsCount
-Buildkite > ScheduledJobsCount
-Buildkite > UnfinishedJobsCount
-Buildkite > IdleAgentsCount
-Buildkite > BusyAgentsCount
-Buildkite > TotalAgentsCount
+Buildkite > (Org) > RunningJobsCount
+Buildkite > (Org) > ScheduledJobsCount
+Buildkite > (Org) > UnfinishedJobsCount
+Buildkite > (Org) > IdleAgentsCount
+Buildkite > (Org) > BusyAgentsCount
+Buildkite > (Org) > TotalAgentsCount
 
-Buildkite > (Queue) > RunningJobsCount
-Buildkite > (Queue) > ScheduledJobsCount
-Buildkite > (Queue) > UnfinishedJobsCount
-Buildkite > (Queue) > IdleAgentsCount
-Buildkite > (Queue) > BusyAgentsCount
-Buildkite > (Queue) > TotalAgentsCount
+Buildkite > (Org, Queue) > RunningJobsCount
+Buildkite > (Org, Queue) > ScheduledJobsCount
+Buildkite > (Org, Queue) > UnfinishedJobsCount
+Buildkite > (Org, Queue) > IdleAgentsCount
+Buildkite > (Org, Queue) > BusyAgentsCount
+Buildkite > (Org, Queue) > TotalAgentsCount
 ```
 
 When a queue is specified, only that queue's metrics are published.

--- a/backend/cloudwatch.go
+++ b/backend/cloudwatch.go
@@ -68,15 +68,9 @@ func (cb *CloudWatchBackend) Collect(r *collector.Result) error {
 			})
 		}
 
-		// Add the queue first
+		// Add the queue and org dimensions
 		dimensions = append(dimensions,
 			&cloudwatch.Dimension{Name: aws.String("Queue"), Value: aws.String(name)},
-		)
-
-		metrics = append(metrics, cloudwatchMetrics(c, dimensions)...)
-
-		// Then the queue + the org
-		dimensions = append(dimensions,
 			&cloudwatch.Dimension{Name: aws.String("Org"), Value: aws.String(r.Org)},
 		)
 


### PR DESCRIPTION
In 5.0, we will remove metrics with just a Queue dimension in favour of a default of Queue, Org.