### PR TITLE
Support multiple queue params

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Restrict it to a single queue with `-queue` if you're scaling a single cluster o
 buildkite-agent-metrics -token abc123 -interval 30s -queue my-queue
 ```
 
+Restrict it to a multiple queues with `-queue`:
+
+```
+buildkite-agent-metrics -token abc123 -interval 30s -queue my-queue1 -queue my-queue2
+```
+
 ### Running as an AWS Lambda
 
 An AWS Lambda bundle is created and published as part of the build process. The lambda will require the [`cloudwatch:PutMetricData`](https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/publishingMetrics.html) IAM permission.

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -247,7 +247,7 @@ func TestCollectorWithSomeJobsAndAgentsForAQueue(t *testing.T) {
 		Endpoint:  s.URL,
 		Token:     "abc123",
 		UserAgent: "some-client/1.2.3",
-		Queue:     "deploy",
+		Queues:    []string{"deploy"},
 	}
 	res, err := c.Collect()
 	if err != nil {

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -63,7 +63,7 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 		UserAgent: userAgent,
 		Endpoint:  "https://agent.buildkite.com/v3",
 		Token:     token,
-		Queue:     queue,
+		Queues:    []string{queue},
 		Quiet:     quiet,
 		Debug:     false,
 		DebugHttp: false,

--- a/main.go
+++ b/main.go
@@ -36,10 +36,11 @@ func main() {
 		clwRegion      = flag.String("cloudwatch-region", "", "AWS Region to connect to, defaults to $AWS_REGION or us-east-1")
 		clwDimensions  = flag.String("cloudwatch-dimensions", "", "Cloudwatch dimensions to index metrics under, in the form of Key=Value, Other=Value")
 		gcpProjectID   = flag.String("stackdriver-projectid", "", "Specify Stackdriver Project ID")
-
-		// filters
-		queue = flag.String("queue", "", "Only include a specific queue")
 	)
+
+	// custom config for multiple queues
+	var queues stringSliceFlag
+	flag.Var(&queues, "queue", "Specific queues to process")
 
 	flag.Parse()
 
@@ -101,7 +102,7 @@ func main() {
 		UserAgent: userAgent,
 		Endpoint:  *endpoint,
 		Token:     *token,
-		Queue:     *queue,
+		Queues:    []string(queues),
 		Quiet:     *quiet,
 		Debug:     *debug,
 		DebugHttp: *debugHttp,
@@ -152,4 +153,15 @@ func main() {
 			}
 		}
 	}
+}
+
+type stringSliceFlag []string
+
+func (i *stringSliceFlag) String() string {
+	return fmt.Sprintf("%v", *i)
+}
+
+func (i *stringSliceFlag) Set(value string) error {
+	*i = append(*i, value)
+	return nil
 }


### PR DESCRIPTION
This adds support for multiple queues:

```bash
buildkite-agent-metrics -token abc123 -interval 30s -queue my-queue1 -queue my-queue2
```