### PR TITLE
stackdriver: Use organization specific metric names.

### DIFF
--- a/backend/cloudwatch.go
+++ b/backend/cloudwatch.go
@@ -60,7 +60,7 @@ func (cb *CloudWatchBackend) Collect(r *collector.Result) error {
 		return err
 	}
 
-  svc := cloudwatch.New(sess)
+	svc := cloudwatch.New(sess)
 	metrics := []*cloudwatch.MetricDatum{}
 
 	// Set the baseline org dimension
@@ -68,7 +68,7 @@ func (cb *CloudWatchBackend) Collect(r *collector.Result) error {
 		&cloudwatch.Dimension{Name: aws.String("Org"), Value: aws.String(r.Org)},
 	}
 
-  // Add custom dimension if provided
+	// Add custom dimension if provided
 	for _, d := range cb.dimensions {
 		log.Printf("Using custom Cloudwatch dimension of [ %s = %s ]", d.Key, d.Value)
 

--- a/backend/ssm.go
+++ b/backend/ssm.go
@@ -2,10 +2,11 @@ package backend
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ssm"
-	"os"
 )
 
 func RetrieveFromParameterStore(key string) string {

--- a/backend/stackdriver.go
+++ b/backend/stackdriver.go
@@ -24,7 +24,7 @@ const (
 
 // StackDriverBackend sends metrics to GCP Stackdriver
 type StackDriverBackend struct {
-	projectId   string
+	projectID   string
 	client      *monitoring.MetricClient
 	metricTypes map[string]string
 }
@@ -38,12 +38,13 @@ func NewStackDriverBackend(gcpProjectID string) (*StackDriverBackend, error) {
 	}
 
 	return &StackDriverBackend{
-		projectId:   gcpProjectID,
+		projectID:   gcpProjectID,
 		client:      c,
 		metricTypes: make(map[string]string),
 	}, nil
 }
 
+// Collect metrics
 func (sd *StackDriverBackend) Collect(r *collector.Result) error {
 	ctx := context.Background()
 	now := &timestamp.Timestamp{
@@ -53,7 +54,7 @@ func (sd *StackDriverBackend) Collect(r *collector.Result) error {
 		mt, present := sd.metricTypes[name]
 		if !present {
 			mt = fmt.Sprintf(metricTotalPrefix, name)
-			metricReq := createCustomMetricRequest(&sd.projectId, &mt)
+			metricReq := createCustomMetricRequest(&sd.projectID, &mt)
 			_, err := sd.client.CreateMetricDescriptor(ctx, metricReq)
 			if err != nil {
 				retErr := fmt.Errorf("[Collect] could not create custom metric [%s]: %v", mt, err)
@@ -63,7 +64,7 @@ func (sd *StackDriverBackend) Collect(r *collector.Result) error {
 			log.Printf("[Collect] created custom metric [%s]", mt)
 			sd.metricTypes[name] = mt
 		}
-		req := createTimeSeriesValueRequest(&sd.projectId, &mt, totalMetricsQueue, value, now)
+		req := createTimeSeriesValueRequest(&sd.projectID, &mt, totalMetricsQueue, value, now)
 		err := sd.client.CreateTimeSeries(ctx, req)
 		if err != nil {
 			retErr := fmt.Errorf("[Collect] could not write metric [%s] value [%d], %v ", mt, value, err)
@@ -75,7 +76,7 @@ func (sd *StackDriverBackend) Collect(r *collector.Result) error {
 	for queue, counts := range r.Queues {
 		for name, value := range counts {
 			mt := fmt.Sprintf(metricTotalPrefix, name)
-			req := createTimeSeriesValueRequest(&sd.projectId, &mt, queue, value, now)
+			req := createTimeSeriesValueRequest(&sd.projectID, &mt, queue, value, now)
 			err := sd.client.CreateTimeSeries(ctx, req)
 			if err != nil {
 				retErr := fmt.Errorf("[Collect] could not write metric [%s] value [%d], %v ", mt, value, err)


### PR DESCRIPTION
The current buildkite-agent-metrics daemon can only collect and export data for a single organization. 

Users who use multiple Buildkite organizations within a single Google Cloud project (e.g. bazel and bazel-testing) have to launch multiple instances of the daemon, each with the organization-specific agent token.

However, because the daemon didn't take the organization name into account when generating the metrics name, the daemons would try to write into each others Stackdriver metrics, causing API errors due to too frequent updates and data from multiple orgs being mixed.

It seems like a nice way to solve this is to use the organization name as part of the metric name.