### PR TITLE
feat: don't exit on collect errors

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -113,7 +113,7 @@ func (c *Collector) Collect() (*Result, error) {
 		}
 
 		httpClient := &http.Client{
-			Timeout: 5 * time.Second,
+			Timeout: 15 * time.Second,
 		}
 
 		res, err := httpClient.Do(req)

--- a/main.go
+++ b/main.go
@@ -137,7 +137,6 @@ func main() {
 	minPollDuration, err := f()
 	if err != nil {
 		fmt.Println(err)
-		os.Exit(1)
 	}
 
 	if *interval > 0 {
@@ -156,7 +155,6 @@ func main() {
 			minPollDuration, err = f()
 			if err != nil {
 				fmt.Println(err)
-				os.Exit(1)
 			}
 		}
 	}


### PR DESCRIPTION
I'm using the agent metrics with `docker`, and I notice an unusual number of restarts of the container on our Kubernetes:

```NAME                                 READY   STATUS    RESTARTS   AGE
buildkite-metrics-66cf555bfc-xn668   1/1     Running   55         37d
```

Looking over the logs, I saw that whenever there's a fail of communication, the container restarts, because of the `os.Exit(1)` on the main:

```
2019/09/17 10:26:49 Collecting agent metrics for all queues
Get https://agent.buildkite.com/v3/metrics: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
exit status 1
```

My proposal is to not exit when there's a error on the `Collect`, just log the error, so we can have the agent running without exiting:

```
2019/09/17 10:33:03 Collecting agent metrics for all queues
Get https://agent.buildkite.com/v3/metrics: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
2019/09/17 10:33:08 Waiting for 15s (minimum of 0s)
2019/09/17 10:33:23 Collecting agent metrics for all queues
Get https://agent.buildkite.com/v3/metrics: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
2019/09/17 10:33:28 Waiting for 15s (minimum of 0s)
2019/09/17 10:33:43 Collecting agent metrics for all queues
Get https://agent.buildkite.com/v3/metrics: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
2019/09/17 10:33:48 Waiting for 15s (minimum of 0s)
```

I also increased the client HTTP timeout a few seconds.