### PR TITLE
Allow lambda BUILDKITE_QUEUE envvar to be a comma separated list

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ It's entrypoint is `handler`, it requires a `go1.x` environment and respects the
 
  - BUILDKITE_AGENT_TOKEN
  - BUILDKITE_BACKEND
- - BUILDKITE_QUEUE
+ - BUILDKITE_QUEUE (may be a comma separated list of queues to monitor)
  - BUILDKITE_QUIET
  - BUILDKITE_CLOUDWATCH_DIMENSIONS
 

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -57,9 +57,9 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 		token = backend.RetrieveFromParameterStore(ssmTokenKey)
 	}
 
-	var queues = []string{}
+	queues := []string{}
 	if queue != "" {
-		queues = append(queues, queue)
+		queues = strings.Split(queue, ",")
 	}
 
 	userAgent := fmt.Sprintf("buildkite-agent-metrics/%s buildkite-agent-metrics-lambda", version.Version)


### PR DESCRIPTION
To allow the metrics lambda to support monitoring multiple queues, we can perform a string split by comma if it is not-empty. `strings.Split` preserves expected functionality of a single queue if there are no commas:
```sh
gore> :import "strings"
gore> strings.Split("one-queue", ",")
[]string{"one-queue"}
gore> strings.Split("first-queue,second-queue", ",")
[]string{"first-queue", "second-queue"}
```