### PR TITLE
Fix tests in collector/collector_test.go

### DIFF
--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -12,7 +12,7 @@ func TestCollectorWithEmptyResponseForAllQueues(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/metrics" {
 			w.WriteHeader(http.StatusOK)
-			io.WriteString(w, `{}`)
+			io.WriteString(w, `{"organization": { "slug": "some-org-slug"}}`)
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -57,7 +57,7 @@ func TestCollectorWithNoJobsForAllQueues(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/metrics" {
 			w.WriteHeader(http.StatusOK)
-			io.WriteString(w, `{"jobs":{"scheduled":0,"running":0,"all":0,"queues":{}},"agents":{"idle":0,"busy":0,"all":0,"queues":{}}}`)
+			io.WriteString(w, `{"jobs":{"scheduled":0,"running":0,"all":0,"queues":{}},"agents":{"idle":0,"busy":0,"all":0,"queues":{}}, "organization": {"slug": "some-org-slug"}}`)
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -102,7 +102,7 @@ func TestCollectorWithSomeJobsAndAgentsForAllQueues(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/metrics" {
 			w.WriteHeader(http.StatusOK)
-			io.WriteString(w, `{"jobs":{"scheduled":3,"running":1,"total":4,"queues":{"default":{"scheduled":2,"running":1,"total":3},"deploy":{"scheduled":1,"running":0,"total":1}}},"agents":{"idle":0,"busy":1,"total":1,"queues":{"default":{"idle":0,"busy":1,"total":1}}}}`)
+			io.WriteString(w, `{"jobs":{"scheduled":3,"running":1,"total":4,"queues":{"default":{"scheduled":2,"running":1,"total":3},"deploy":{"scheduled":1,"running":0,"total":1}}},"agents":{"idle":0,"busy":1,"total":1,"queues":{"default":{"idle":0,"busy":1,"total":1}}}, "organization": {"slug": "some-org-slug"}}`)
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -166,7 +166,7 @@ func TestCollectorWithSomeJobsAndAgentsForAQueue(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/metrics/queue" && r.URL.Query().Get("name") == "deploy" {
 			w.WriteHeader(http.StatusOK)
-			io.WriteString(w, `{"jobs":{"scheduled":3,"running":1,"total":4},"agents":{"idle":0,"busy":1,"total":1}}`)
+			io.WriteString(w, `{"jobs":{"scheduled":3,"running":1,"total":4},"agents":{"idle":0,"busy":1,"total":1}, "organization": {"slug" : "some-org-slug"}}`)
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}


### PR DESCRIPTION
## Intent
To fix failing tests in `collector/collector_test.go`.

## Problem
The tests were failing due to the mocked `JSON` response not having the `organization` field.

## Solution
To add a mock `organization` struct to all mocked `JSON` responses.