### PR TITLE
fix reversed comparison

### DIFF
--- a/lambda/main.go
+++ b/lambda/main.go
@@ -180,9 +180,9 @@ func initTokenProvider(awsRegion string) (token.Provider, error) {
 		}
 		client := secretsmanager.New(sess)
 		if jsonKey == "" {
-			return token.NewSecretsManager(client, secretsManagerSecretID, token.WithSecretsManagerJSONSecret(jsonKey))
-		} else {
 			return token.NewSecretsManager(client, secretsManagerSecretID)
+		} else {
+			return token.NewSecretsManager(client, secretsManagerSecretID, token.WithSecretsManagerJSONSecret(jsonKey))
 		}
 	}
 


### PR DESCRIPTION
the logic is revered in the code, when `jsonKey` is empty it tries to use it, which results in

```
The token you provided "
{
    "token": "<REDACTED>"
}
" is not a valid organization agent registration token: errorString
```