### PR TITLE
update release-related steps to work on the new deploy queue

### DIFF
--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -14,4 +14,11 @@ steps:
       queue: "deploy"
     concurrency: 1
     concurrency_group: 'release_buildkite_metrics_github'
+    plugins:
+      - ecr#v2.0.0:
+          login: true
+          account-ids: "032379705303"
+      - docker#v3.5.0:
+          image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2020.03"
+          propagate-environment: true
 

--- a/.buildkite/steps/release-github.sh
+++ b/.buildkite/steps/release-github.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -e
 
-GITHUB_RELEASE_IMAGE="buildkite/github-release@sha256:e5ae9753a8246ace67f3669baa63103429367c999bfda0a227c91a4ebf34c23f"
+echo '--- Getting credentials from SSM'
+export GITHUB_RELEASE_ACCESS_TOKEN=$(aws ssm get-parameter --name /pipelines/buildkite-agent-metrics/GITHUB_RELEASE_ACCESS_TOKEN --with-decryption --output text --query Parameter.Value --region us-east-1)
 
 if [[ "$GITHUB_RELEASE_ACCESS_TOKEN" == "" ]]; then
   echo "Error: Missing \$GITHUB_RELEASE_ACCESS_TOKEN"
@@ -17,7 +18,7 @@ mkdir -p dist
 buildkite-agent artifact download handler.zip ./dist
 buildkite-agent artifact download "buildkite-agent-metrics-*" ./dist
 
-docker run -v "$PWD:$PWD" -w "$PWD" -e GITHUB_RELEASE_ACCESS_TOKEN --rm "${GITHUB_RELEASE_IMAGE}" "v${version}" dist/* \
+github-release "v${version}" dist/* \
   --commit "${BUILDKITE_COMMIT}" \
   --tag "v${version}" \
   --github-repository "buildkite/buildkite-agent-metrics"


### PR DESCRIPTION
The agents processing the `deploy` queue have changed to an elastic stack.

They have the tools required (awscli, docker) and the required IAM permissions (uploading to S3), but we need to read the github API from SSM ourselves.

One of the steps also uses `github-release`, which isn't available on the elastic stack. I've switched from manually running a docker container with the binary, to running the entire step in a container that has it. This is mainly for consistency with other pipelines that use `github-release`.