### PR TITLE
go.mod: Adds Golang version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/buildkite/buildkite-agent-metrics
 
+go 1.12
+
 require (
 	cloud.google.com/go v0.37.2
 	github.com/DataDog/datadog-go v0.0.0-20180822151419-281ae9f2d895


### PR DESCRIPTION
## Intent
To specify the Golang version in the `go.mod` file.

## Problem
Building the `lambda` package using `go >= 1.14` breaks.

```
go: inconsistent vendoring in /Users/alloveras/go/src/github.com/alloveras/buildkite-agent-metrics:
	cloud.google.com/go@v0.37.2: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/DataDog/datadog-go@v0.0.0-20180822151419-281ae9f2d895: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/aws/aws-lambda-go@v1.6.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/aws/aws-sdk-go@v1.15.66: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/golang/mock@v1.2.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/golang/protobuf@v1.2.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/jmespath/go-jmespath@v0.0.0-20180206201540-c2b33e8439af: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/newrelic/go-agent@v2.7.0+incompatible: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/prometheus/client_golang@v0.9.3-0.20190127221311-3c4408c8b829: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/prometheus/client_model@v0.0.0-20190115171406-56726106282f: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	google.golang.org/genproto@v0.0.0-20190401181712-f467c93bbac2: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	gopkg.in/yaml.v2@v2.2.2: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt

run 'go mod vendor' to sync, or use -mod=mod or -mod=readonly to ignore the vendor directory
```

There root cause for that is:
 - The `vendor` directory has become out of date for some of the dependencies used within the `lambda` package. However, it seems to be OK for the rest of the code-base in this repository.
 - In [`go >= 1.14`](https://golang.org/doc/go1.14) the `go build` and other commands default to favor the`vendor` directory (if exists) over the modules cache.

    > When the main module contains a top-level vendor directory and its go.mod file specifies go 1.14 or higher, the go command now defaults to -mod=vendor for operations that accept that flag. A new value for that flag, -mod=mod, causes the go command to instead load modules from the module cache (as when no vendor directory is present).

Thus, not having `go 1.12` specified in the `go.mod` file and building with `go >= 1.14` causes `go.mod` to assume the go version is `1.14` and thus, break the build.

## Solution
To add the `go 1.12` clause within `go.mod` to prevent this problem without having to update the `vendor` directory.

--- 
PS1: Ideally we should remove the `vendor` directory if we are using Go modules. However, that may break some outdated consumers that are still relying on it. Thus, I preferred this change instead that should be less intrusive.

PS2: I took the `go 1.12` version from the `Dockerfile` at the repository root. 

