### PR TITLE
Build the docker image binary using golang 1.16 too

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15 as builder
+FROM golang:1.16 as builder
 WORKDIR /go/src/github.com/buildkite/buildkite-agent-metrics/
 COPY . .
 RUN GO111MODULE=on GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o buildkite-agent-metrics .


### PR DESCRIPTION
Bumped on master in https://github.com/buildkite/buildkite-agent-metrics/commit/f83991c2bb8af7b3ac3a2cd6873e48f201b65599 and https://github.com/buildkite/buildkite-agent-metrics/commit/6ba4f87a877dce2a32e8bb5b5f6dc7665d40dcfe