### PR TITLE
Release updates for 5.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v5.2.1](https://github.com/buildkite/buildkite-agent-metrics/tree/v5.2.0) (2021-07-01)
+[Full Changelog](https://github.com/buildkite/buildkite-agent-metrics/compare/v5.2.0...v5.2.1)
+
+### Added
+
+* Support for more AWS Regions (af-south-1, ap-east-1, ap-southeast-2, ap-southeast-1, eu-south-1, me-south-1) [#109](https://github.com/buildkite/buildkite-agent-metrics/pull/109)
+* ARM64 binaries for Linux and macOS
+
+### Changed
+
+* Build using golang 1.16
+* Update newrelic/go-agent from v2.7.0 to v3.0.0 [#111](https://github.com/buildkite/buildkite-agent-metrics/pull/111) (@mallyvai)
+
 ## [v5.2.0](https://github.com/buildkite/buildkite-agent-metrics/tree/v5.2.0) (2020-03-05)
 [Full Changelog](https://github.com/buildkite/buildkite-agent-metrics/compare/v5.1.0...v5.2.0)
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version the library version number
-const Version = "5.2.0"
+const Version = "5.2.1"


### PR DESCRIPTION
Merging this to master will make the final step in .buildkite/pipeline.yml notice the version number is not a tag and upload the release steps which will make one and attach the binaries.