### PR TITLE
Standardize http.Client collector configurations

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -88,6 +88,10 @@ func (c *Collector) Collect() (*Result, error) {
 		Queues: map[string]map[string]int{},
 	}
 
+	httpClient := &http.Client{
+		Timeout: 15 * time.Second,
+	}
+	
 	if len(c.Queues) == 0 {
 		log.Println("Collecting agent metrics for all queues")
 
@@ -110,10 +114,6 @@ func (c *Collector) Collect() (*Result, error) {
 			if dump, err := httputil.DumpRequest(req, true); err == nil {
 				log.Printf("DEBUG request uri=%s\n%s\n", req.URL, dump)
 			}
-		}
-
-		httpClient := &http.Client{
-			Timeout: 15 * time.Second,
 		}
 
 		res, err := httpClient.Do(req)
@@ -224,7 +224,7 @@ func (c *Collector) Collect() (*Result, error) {
 				}
 			}
 
-			res, err := http.DefaultClient.Do(req)
+			res, err := httpClient.Do(req)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## Intent
The current implementation will use two different `http.Client` configurations depending on whether the collector is targetting ALL queues or only particular ones.

## Problem
When targetting particular queues, the code will use `http.DefaultClient` and, as a consequence of its default values, it will use an infinite client timeout. This is particularly problematic as upstream servers may not have timeouts set either or use a very long one. Hence, when used in the Lambda environment, a bad behaving request can force the function execution time to skyrocket and go past the Lambda execution timeout.

## Solution
To ensure that both configurations (all queues vs particular queues) do use the same HTTP client configurations with a sensible client timeout value.