### PR TITLE
Update release process to use OIDC

### DIFF
--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -4,21 +4,29 @@ steps:
   - label: ":s3:"
     command: ".buildkite/steps/release-s3-version.sh"
     agents:
-      queue: "deploy"
+      queue: "elastic-runners"
     concurrency: 1
     concurrency_group: 'release_buildkite_metrics_github'
+    plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-metrics
 
   - label: ":github:"
     command: ".buildkite/steps/release-github.sh"
     agents:
-      queue: "deploy"
+      queue: "elastic-runners"
     concurrency: 1
     concurrency_group: 'release_buildkite_metrics_github'
     plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::445615400570:role/pipeline-buildkite-agent-metrics
+      - aws-ssm#v1.0.0:
+          parameters:
+            GITHUB_RELEASE_ACCESS_TOKEN: /pipelines/buildkite-agent-metrics/GITHUB_RELEASE_ACCESS_TOKEN
       - ecr#v2.0.0:
           login: true
-          account-ids: "032379705303"
+          account-ids: "445615400570"
       - docker#v3.5.0:
-          image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2020.03"
+          image: "445615400570.dkr.ecr.us-east-1.amazonaws.com/deploytools:2020.03"
           propagate-environment: true
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -43,9 +43,12 @@ steps:
     command: ".buildkite/steps/upload-to-s3.sh"
     branches: master
     agents:
-      queue: "deploy"
+      queue: "elastic-runners"
     concurrency: 1
     concurrency_group: "release_buildkite_metrics_s3"
+    plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-agent-metrics
 
   - wait
   - name: ":pipeline:"

--- a/.buildkite/steps/release-github.sh
+++ b/.buildkite/steps/release-github.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -e
 
-echo '--- Getting credentials from SSM'
-export GITHUB_RELEASE_ACCESS_TOKEN=$(aws ssm get-parameter --name /pipelines/buildkite-agent-metrics/GITHUB_RELEASE_ACCESS_TOKEN --with-decryption --output text --query Parameter.Value --region us-east-1)
-
 if [[ "$GITHUB_RELEASE_ACCESS_TOKEN" == "" ]]; then
   echo "Error: Missing \$GITHUB_RELEASE_ACCESS_TOKEN"
   exit 1


### PR DESCRIPTION
Now that OIDC is available, we prefer to use it to assume specific IAM roles for deploy tasks.

For pushing to S3, assume an IAM role from the account where the S3 buckets live.

For releasing to GitHub, assume role in the account running the step and use that to set an ENV var from SSM Parameter Store