### PR TITLE
Allow dependabot to slowly keep gomod up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: /
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2
+    reviewers:
+      - "buildkite/pipelines-dispatch"
+


### PR DESCRIPTION
We recently (#131) did a bulk update to many go modules, fixing various security issues.

This configures dependabot to open PRs with occasional version bumps. We don't want to wake up to 100 PRs each Monday though, so only allow two PRs at a time. In a small project like this, a couple of bumps per week should be plenty. Maybe we could even tune it down further. 2 per month?