### PR TITLE
v5.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v5.5.1](https://github.com/buildkite/buildkite-agent-metrics/tree/v5.5.1) (2023-04-05)
+[Full Changelog](https://github.com/buildkite/buildkite-agent-metrics/compare/v5.5.0...v5.5.1)
+
+### Changed
+- Update release process to generate checksums [#145](https://github.com/buildkite/buildkite-agent-metrics/pull/145) (@triarius)
+- Allow dependabot to slowly keep gomod up to date [#135](https://github.com/buildkite/buildkite-agent-metrics/pull/135) (@yob)
+- Dependency updates (@dependabot[bot])
+
 ## [v5.5.0](https://github.com/buildkite/buildkite-agent-metrics/tree/v5.5.0) (2023-03-16)
 [Full Changelog](https://github.com/buildkite/buildkite-agent-metrics/compare/v5.4.0...v5.5.0)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,7 @@
 # Release Instructions
 
-1. Determine the SemVer version for the new release: `$VERSION`.
-1. Generate a changelog using [ghch](https://github.com/buildkite/ghch) `ghch --format=markdown --next-version=$VERSION`.
+1. Determine the SemVer version for the new release: `$VERSION`. Note: [semver does not include a `v` prefix](https://github.com/semver/semver/blob/master/semver.md#is-v123-a-semantic-version).
+1. Generate a changelog using [ghch](https://github.com/buildkite/ghch) `ghch --format=markdown --next-version=v$VERSION`.
 1. Create a new branch `git fetch origin && git switch -c release/$VERSION`.
 1. Update [CHANGELOG.md](CHANEGLOG.md) with the generated changelog.
 1. Update [`version/version.go`](version/version.go) with the new version.

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version the library version number
-const Version = "5.5.0"
+const Version = "5.5.1"


### PR DESCRIPTION
## [v5.5.1](https://github.com/buildkite/buildkite-agent-metrics/tree/v5.5.1) (2023-04-05)
[Full Changelog](https://github.com/buildkite/buildkite-agent-metrics/compare/v5.5.0...v5.5.1)

### Changed
- Update release process to generate checksums [#145](https://github.com/buildkite/buildkite-agent-metrics/pull/145) (@triarius)
- Allow dependabot to slowly keep gomod up to date [#135](https://github.com/buildkite/buildkite-agent-metrics/pull/135) (@yob)
- Dependency updates (@dependabot[bot])