### PR TITLE
v5.5.3

### DIFF
--- a/.buildkite/steps/release-github.sh
+++ b/.buildkite/steps/release-github.sh
@@ -38,12 +38,14 @@ if [[ "${RELEASE_DRY_RUN:-false}" != true ]] && ! grep "^## \[$escaped_tag\]" CH
   exit 1
 fi
 
-pushd dist
+echo --- Creating checksum file
+pushd dist &>/dev/null
 set +f
 sha256sum -- * > sha256sums.txt
 set -f
-popd
+popd &>/dev/null
 
+echo --- The following notes will accompany the release:
 # The three commands below:
 #   Find lines between headers of the changelogs (inclusive)
 #   Delete the lines included from the headers
@@ -54,8 +56,6 @@ notes=$(
     | sed '1d;$d' \
     | sed '/./,$!d' \
 )
-
-echo --- The following notes will accompany the release:
 echo "$notes"
 
 echo --- :github: Publishing draft release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v5.5.3](https://github.com/buildkite/buildkite-agent-metrics/tree/v5.5.3) (2023-04-10)
+[Full Changelog](https://github.com/buildkite/buildkite-agent-metrics/compare/v5.5.2...v5.5.3)
+
+### Changed
+- More fixes to release automation [#149](https://github.com/buildkite/buildkite-agent-metrics/pull/149) (@triarius)
+
 ## [v5.5.2](https://github.com/buildkite/buildkite-agent-metrics/tree/v5.5.2) (2023-04-09)
 [Full Changelog](https://github.com/buildkite/buildkite-agent-metrics/compare/v5.5.1...v5.5.2)
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version the library version number
-const Version = "5.5.2"
+const Version = "5.5.3"


### PR DESCRIPTION
## [v5.5.3](https://github.com/buildkite/buildkite-agent-metrics/tree/v5.5.3) (2023-04-10)
[Full Changelog](https://github.com/buildkite/buildkite-agent-metrics/compare/v5.5.2...v5.5.3)

### Changed
- Fix RELEASE_DRY_RUN [#149](https://github.com/buildkite/buildkite-agent-metrics/pull/149) (@triarius)