### PR TITLE
Fix `--verify-tag` not available in github-cli 2.20

### DIFF
--- a/.buildkite/steps/release-github.sh
+++ b/.buildkite/steps/release-github.sh
@@ -64,7 +64,8 @@ GITHUB_TOKEN="$GITHUB_RELEASE_ACCESS_TOKEN" \
   release_dry_run gh release create \
     --draft \
     --notes "'$notes'" \
-    --verify-tag \
+    # TODO: uncomment once github-cli in alpine repo hits v2.27+
+    # --verify-tag \
     "v$version" \
     dist/*
 set -f


### PR DESCRIPTION
Once an updated version is available in the alpine repos, we can
uncomment this.