### PR TITLE
v5.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v5.5.5](https://github.com/buildkite/buildkite-agent-metrics/tree/v5.5.5) (2023-04-10)
+[Full Changelog](https://github.com/buildkite/buildkite-agent-metrics/compare/v5.5.4...v5.5.5)
+
+### Changed
+- add notes about what the job states mean [#130](https://github.com/buildkite/buildkite-agent-metrics/pull/130) (@edmund-huber)
+- More fixes to the automated release [#153](https://github.com/buildkite/buildkite-agent-metrics/pull/153) (@triarius)
+
 ## [v5.5.4](https://github.com/buildkite/buildkite-agent-metrics/tree/v5.5.4) (2023-04-10)
 [Full Changelog](https://github.com/buildkite/buildkite-agent-metrics/compare/v5.5.3...v5.5.4)
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version the library version number
-const Version = "5.5.4"
+const Version = "5.5.5"


### PR DESCRIPTION
## [v5.5.5](https://github.com/buildkite/buildkite-agent-metrics/tree/v5.5.5) (2023-04-10)
[Full Changelog](https://github.com/buildkite/buildkite-agent-metrics/compare/v5.5.4...v5.5.5)

### Changed
- add notes about what the job states mean [#130](https://github.com/buildkite/buildkite-agent-metrics/pull/130) (@edmund-huber)
- More fixes to the automated release [#153](https://github.com/buildkite/buildkite-agent-metrics/pull/153) (@triarius)