### PR TITLE
Make timeout a configurable value.

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -34,6 +34,7 @@ type Collector struct {
 	Quiet     bool
 	Debug     bool
 	DebugHttp bool
+	Timeout   int
 }
 
 type Result struct {
@@ -89,7 +90,7 @@ func (c *Collector) Collect() (*Result, error) {
 	}
 
 	httpClient := &http.Client{
-		Timeout: 15 * time.Second,
+		Timeout: time.Duration(c.Timeout) * time.Second,
 	}
 
 	if len(c.Queues) == 0 {

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ func main() {
 		debugHttp   = flag.Bool("debug-http", false, "Show full http traces")
 		dryRun      = flag.Bool("dry-run", false, "Whether to only print metrics")
 		endpoint    = flag.String("endpoint", "https://agent.buildkite.com/v3", "A custom Buildkite Agent API endpoint")
+		timeout     = flag.Int("timeout", 15, "Timeout, in seconds, for HTTP requests to Buildkite API")
 
 		// backend config
 		backendOpt     = flag.String("backend", "cloudwatch", "Specify the backend to use: cloudwatch, statsd, prometheus, stackdriver")
@@ -117,6 +118,7 @@ func main() {
 		Quiet:     *quiet,
 		Debug:     *debug,
 		DebugHttp: *debugHttp,
+		Timeout:   *timeout,
 	}
 
 	f := func() (time.Duration, error) {


### PR DESCRIPTION
This change maintains the default timeout of 15 seconds but allows folks to change the timeout to a value they wish to set instead if they're noticing more frequent timeout issues such as `Client.Timeout exceeded while awaiting headers`