### PR TITLE
Make the timeout configurable

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -34,6 +34,7 @@ type Collector struct {
 	Quiet     bool
 	Debug     bool
 	DebugHttp bool
+	Timeout   int
 }
 
 type Result struct {
@@ -89,7 +90,7 @@ func (c *Collector) Collect() (*Result, error) {
 	}
 
 	httpClient := &http.Client{
-		Timeout: 15 * time.Second,
+		Timeout: time.Duration(c.Timeout) * time.Second,
 	}
 
 	if len(c.Queues) == 0 {

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ func main() {
 		debugHttp   = flag.Bool("debug-http", false, "Show full http traces")
 		dryRun      = flag.Bool("dry-run", false, "Whether to only print metrics")
 		endpoint    = flag.String("endpoint", "https://agent.buildkite.com/v3", "A custom Buildkite Agent API endpoint")
+		timeout     = flag.Int("timeout", 15, "Timeout, in seconds, for HTTP requests to Buildkite API")
 
 		// backend config
 		backendOpt     = flag.String("backend", "cloudwatch", "Specify the backend to use: cloudwatch, statsd, prometheus, stackdriver")
@@ -117,6 +118,7 @@ func main() {
 		Quiet:     *quiet,
 		Debug:     *debug,
 		DebugHttp: *debugHttp,
+		Timeout:   *timeout,
 	}
 
 	f := func() (time.Duration, error) {


### PR DESCRIPTION
By default, the http `timeout` is set to 15 seconds, which is mostly fine. However, if folks are seeing timeouts occur it might be nice if we let them adjust the timeout on the http calls so that they can test prior to raising an issue. This change ensures that the default remains at 15 seconds, which may or may not have been picked for a reason, where someone doesn't opt to set it, but gives the option to do so. It also doesn't create a global increase of timeouts.
