### PR TITLE
feat(collector): exit on 401 response

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -25,6 +24,10 @@ const (
 	BusyAgentPercentage = "BusyAgentPercentage"
 
 	PollDurationHeader = `Buildkite-Agent-Metrics-Poll-Duration`
+)
+
+var (
+	ErrUnauthorized = errors.New("unauthorized")
 )
 
 type Collector struct {
@@ -123,7 +126,7 @@ func (c *Collector) Collect() (*Result, error) {
 			// Authorization error signals token is invalid
 			if res.StatusCode == 401 {
 				log.Printf("DEBUG HTTP 401 returned from uri=%s\n", req.URL)
-				os.Exit(1)
+				return nil, fmt.Errorf("http 401 response received %w", ErrUnauthorized)
 			}
 			return nil, err
 		}

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -122,7 +122,7 @@ func (c *Collector) Collect() (*Result, error) {
 		if err != nil {
 			// Authorization error signals token is invalid
 			if res.StatusCode == 401 {
-				log.Printf("DEBUG HTTP 401 returned from uri=%s", req.URL)
+				log.Printf("DEBUG HTTP 401 returned from uri=%s\n", req.URL)
 				os.Exit(1)
 			}
 			return nil, err

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -124,11 +124,13 @@ func (c *Collector) Collect() (*Result, error) {
 		res, err := httpClient.Do(req)
 		if err != nil {
 			// Authorization error signals token is invalid
+			return nil, err
+		} else {
+			// non-2xx status code don't cause errors so we conditionally off to check
+			// for them
 			if res.StatusCode == 401 {
-				log.Printf("DEBUG HTTP 401 returned from uri=%s\n", req.URL)
 				return nil, fmt.Errorf("http 401 response received %w", ErrUnauthorized)
 			}
-			return nil, err
 		}
 		defer res.Body.Close()
 

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -125,14 +125,12 @@ func (c *Collector) Collect() (*Result, error) {
 		if err != nil {
 			// Authorization error signals token is invalid
 			return nil, err
-		} else {
-			// non-2xx status code don't cause errors so we branch off to check
-			// for them
-			if res.StatusCode == 401 {
-				return nil, fmt.Errorf("http 401 response received %w", ErrUnauthorized)
-			}
 		}
 		defer res.Body.Close()
+
+		if res.StatusCode == 401 {
+			return nil, fmt.Errorf("http 401 response received %w", ErrUnauthorized)
+		}
 
 		if c.DebugHttp {
 			if dump, err := httputil.DumpResponse(res, true); err == nil {

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -126,7 +126,7 @@ func (c *Collector) Collect() (*Result, error) {
 			// Authorization error signals token is invalid
 			return nil, err
 		} else {
-			// non-2xx status code don't cause errors so we conditionally off to check
+			// non-2xx status code don't cause errors so we branch off to check
 			// for them
 			if res.StatusCode == 401 {
 				return nil, fmt.Errorf("http 401 response received %w", ErrUnauthorized)

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -119,6 +120,11 @@ func (c *Collector) Collect() (*Result, error) {
 
 		res, err := httpClient.Do(req)
 		if err != nil {
+			// Authorization error signals token is invalid
+			if res.StatusCode == 401 {
+				log.Printf("DEBUG HTTP 401 returned from uri=%s", req.URL)
+				os.Exit(1)
+			}
 			return nil, err
 		}
 		defer res.Body.Close()

--- a/main.go
+++ b/main.go
@@ -128,7 +128,7 @@ func main() {
 		result, err := c.Collect()
 		if err != nil {
 			fmt.Printf("Error collecting agent metrics, err: %w\n", err)
-			if errors.Unwrap(err) == collector.ErrUnauthorized {
+			if errors.Is(err, collector.ErrUnauthorized) {
 				// Unique exit code to signal HTTP 401
 				os.Exit(4)
 			}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -126,6 +127,11 @@ func main() {
 
 		result, err := c.Collect()
 		if err != nil {
+			fmt.Printf("Error collecting agent metrics, err: %w\n", err)
+			if errors.Unwrap(err) == collector.ErrUnauthorized {
+				// Unique exit code to signal HTTP 401
+				os.Exit(4)
+			}
 			return time.Duration(0), err
 		}
 

--- a/main.go
+++ b/main.go
@@ -127,7 +127,7 @@ func main() {
 
 		result, err := c.Collect()
 		if err != nil {
-			fmt.Printf("Error collecting agent metrics, err: %w\n", err)
+			fmt.Printf("Error collecting agent metrics, err: %s\n", err)
 			if errors.Is(err, collector.ErrUnauthorized) {
 				// Unique exit code to signal HTTP 401
 				os.Exit(4)


### PR DESCRIPTION
## Description
When an invalid token is used for invoking `buildkite-agent-metrics` as a daemon - unauthorized errors are indefinitely output, ideally the process exits at some point to signal that it has encountered an error so the calling process can restart it with the correct token.

@triarius - unsure on where you prefer the process exit, PTAL.

## Notes
Resolves #200 
