### PR TITLE
fix(collector): exit on 401 when queues specified

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -240,6 +240,10 @@ func (c *Collector) Collect() (*Result, error) {
 			}
 			defer res.Body.Close()
 
+			if res.StatusCode == 401 {
+				return nil, fmt.Errorf("http 401 response received %w", ErrUnauthorized)
+			}
+
 			if c.DebugHttp {
 				if dump, err := httputil.DumpResponse(res, true); err == nil {
 					log.Printf("DEBUG response uri=%s\n%s\n", req.URL, dump)

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -123,7 +123,6 @@ func (c *Collector) Collect() (*Result, error) {
 
 		res, err := httpClient.Do(req)
 		if err != nil {
-			// Authorization error signals token is invalid
 			return nil, err
 		}
 		defer res.Body.Close()


### PR DESCRIPTION
## Context
In https://github.com/buildkite/buildkite-agent-metrics/pull/203 in `//collector/collector.go` we used error wrapping to exit with code 4 on a 401 response from the agent metrics API. However this was only done in the conditional branch when no queues are specified (i.e. ingest metrics for all queues). Hence when specifying a queue via `-queue` CLI flag, we do not get the exit on status code 401.

## Intent
Exit on 401 response in the conditional branch where `len(c.Queues) != 0` for parity with `len(c.Queues) == 0`.

## Reviewers
@triarius @DrJosh9000 PTAL.
