### PR TITLE
feat(gcp): add env vars for buildkite queues and gcp project id

### DIFF
--- a/main.go
+++ b/main.go
@@ -115,7 +115,7 @@ func main() {
 	}
 
 	// Queues passed as flags take precedence. But if no queues are passed in we
-	// check env vars. If no env vars are defined we default of ingesting metrics
+	// check env vars. If no env vars are defined we default to ingesting metrics
 	// for all queues.
 	// NOTE: `BUILDKITE_QUEUES` is a comma separated string of queues
 	// i.e. "default,deploy,test"

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"strings"
@@ -106,7 +106,7 @@ func main() {
 	}
 
 	if *quiet {
-		log.SetOutput(ioutil.Discard)
+		log.SetOutput(io.Discard)
 	}
 
 	userAgent := fmt.Sprintf("buildkite-agent-metrics/%s buildkite-agent-metrics-cli", version.Version)
@@ -117,10 +117,10 @@ func main() {
 	// Queues passed as flags take precedence. But if no queues are passed in we
 	// check env vars. If no env vars are defined we default to ingesting metrics
 	// for all queues.
-	// NOTE: `BUILDKITE_QUEUES` is a comma separated string of queues
+	// NOTE: `BUILDKITE_QUEUE` is a comma separated string of queues
 	// i.e. "default,deploy,test"
 	if len(queues) == 0 {
-		if q, exists := os.LookupEnv(`BUILDKITE_QUEUES`); exists {
+		if q, exists := os.LookupEnv(`BUILDKITE_QUEUE`); exists {
 			queues = strings.Split(q, ",")
 		}
 	}


### PR DESCRIPTION
## Context
There is no functionality that supports population of `gcpProjectId` and `queues` via environment variables. This limits our ability to run this where config is dynamically populated and `gcpProjectId`/`queues` attributes are a concern of the execution environment and not coupled to binary invocation.

## Intent
Use `GCP_PROJECT_ID` and `BUILDKITE_QUEUE` environment variables to populate config. 

## Notes
- If `gcpProjectID` is an empty string we fall back to the environment variable `GCP_PROJECT_ID`.
- If `queues` aren't specified (i.e. `len(queues) == 0`) we fall back to `BUILDKITE_QUEUE` (same as AWS lambda) environment variables.

These changes are backwards compatible to existing usage of this binary. Happy to discuss implementation details if maintainers feel otherwise :)

## Reviewers
@triarius @DrJosh9000  PTAL.