### PR TITLE
Change build process to better support `provided.al2`

### DIFF
--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -26,6 +26,6 @@ steps:
       - aws-ssm#v1.0.0:
           parameters:
             GITHUB_RELEASE_ACCESS_TOKEN: /pipelines/buildkite/buildkite-agent-metrics/GITHUB_RELEASE_ACCESS_TOKEN
-      - docker-compose#v4.11.0:
+      - docker-compose#v4.14.0:
           config: .buildkite/docker-compose.yaml
           run: agent

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -29,6 +29,8 @@ steps:
 
   - name: ":lambda: Build Lambda"
     key: build-lambda
+    depends_on:
+      - test
     command: .buildkite/steps/build-lambda.sh
 
   - name: ":s3: Upload to S3"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,40 +1,31 @@
 steps:
   - name: ":test_tube: Test"
     key: test
+    command: go test -v -race .
     plugins:
-      - docker#v2.0.0:
-          image: "golang:1.20"
-          command: ["go", "test", "-v", "-race", "."]
-          environment:
-            - GO111MODULE=on
+      - docker#v5.9.0:
+          image: golang:1.21
 
-  - name: ":golang: Compile"
-    key: build
-    plugins:
-      - golang-cross-compile#v1.3.0:
-          build: main.go
-          import: github.com/buildkite/buildkite-agent-metrics
-          targets:
-            - version: "1.20.2"
-              goos: linux
-              goarch: amd64
-              gomodule: "on"
-            - version: "1.20.2"
-              goos: linux
-              goarch: arm64
-              gomodule: "on"
-            - version: "1.20.2"
-              goos: windows
-              goarch: amd64
-              gomodule: "on"
-            - version: "1.20.2"
-              goos: darwin
-              goarch: amd64
-              gomodule: "on"
-            - version: "1.20.2"
-              goos: darwin
-              goarch: arm64
-              gomodule: "on"
+  - group: ":hammer_and_wrench: Binary builds"
+    steps:
+    - name: ":{{matrix.os}}: Build {{matrix.os}} {{matrix.arch}} binary"
+      command: .buildkite/steps/build-binary.sh {{matrix.os}} {{matrix.arch}}
+      key: build-binary
+      depends_on:
+        - test
+      plugins:
+        - docker#v5.9.0:
+            image: golang:1.21
+            mount-buildkite-agent: true
+      matrix:
+        setup:
+          os:
+            - darwin
+            - linux
+            - windows
+          arch:
+            - amd64
+            - arm64
 
   - name: ":lambda: Build Lambda"
     key: build-lambda
@@ -58,6 +49,6 @@ steps:
   - name: ":pipeline:"
     key: upload-release-steps
     depends_on:
-      - build
+      - build-binary
       - upload-to-s3
     command: .buildkite/steps/upload-release-steps.sh

--- a/.buildkite/steps/build-binary.sh
+++ b/.buildkite/steps/build-binary.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+set -eu
+
+GOOS=${1:-linux}
+GOARCH=${2:-amd64}
+
+export GOOS
+export GOARCH
+export CGO_ENABLED=0
+
+go build -o "buildkite-agent-metrics-${GOOS}-${GOARCH}" .
+buildkite-agent artifact upload "buildkite-agent-metrics-${GOOS}-${GOARCH}"

--- a/.buildkite/steps/build-lambda.sh
+++ b/.buildkite/steps/build-lambda.sh
@@ -4,12 +4,13 @@ set -eu
 docker run --rm --volume "$PWD:/code" \
   --workdir "/code" \
   --rm \
-    golang:1.20 \
-    sh -c "go get ./lambda && go build -o ./lambda/handler ./lambda"
+  --env CGO_ENABLED=0 \
+  golang:1.20 \
+    go build -tags lambda.norpc -o lambda/bootstrap ./lambda
 
-chmod +x ./lambda/handler
+chmod +x lambda/bootstrap
 
 mkdir -p dist/
-zip -j handler.zip lambda/handler
+zip -j handler.zip lambda/bootstrap
 
 buildkite-agent artifact upload handler.zip

--- a/.buildkite/steps/build-lambda.sh
+++ b/.buildkite/steps/build-lambda.sh
@@ -2,7 +2,7 @@
 set -eu
 
 docker run --rm --volume "$PWD:/code" \
-  --workdir "/code" \
+  --workdir /code \
   --rm \
   --env CGO_ENABLED=0 \
   golang:1.20 \

--- a/.buildkite/steps/build-lambda.sh
+++ b/.buildkite/steps/build-lambda.sh
@@ -1,11 +1,12 @@
-#!/bin/bash
+#!/usr/bin/env sh
+
 set -eu
 
 docker run --rm --volume "$PWD:/code" \
   --workdir /code \
   --rm \
   --env CGO_ENABLED=0 \
-  golang:1.20 \
+  golang:1.21 \
     go build -tags lambda.norpc -o lambda/bootstrap ./lambda
 
 chmod +x lambda/bootstrap

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.20 as builder
+FROM golang:1.21 as builder
 WORKDIR /go/src/github.com/buildkite/buildkite-agent-metrics/
 COPY . .
 RUN GO111MODULE=on GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o buildkite-agent-metrics .
 
-FROM alpine:3.17
+FROM alpine:3.18
 RUN apk update && apk add curl ca-certificates
 COPY --from=builder /go/src/github.com/buildkite/buildkite-agent-metrics/buildkite-agent-metrics .
 EXPOSE 8080 8125

--- a/Dockerfile.lambda
+++ b/Dockerfile.lambda
@@ -4,4 +4,4 @@ RUN yum install -y unzip wget && \
     wget "https://github.com/buildkite/buildkite-agent-metrics/releases/latest/download/handler.zip" && \
     unzip handler.zip && rm -f handler.zip
 
-ENTRYPOINT ["./handler"]
+ENTRYPOINT ["./bootstrap"]

--- a/README.md
+++ b/README.md
@@ -41,39 +41,39 @@ buildkite-agent-metrics -token abc123 -interval 30s -queue my-queue1 -queue my-q
 
 An AWS Lambda bundle is created and published as part of the build process. The lambda will require the [`cloudwatch:PutMetricData`](https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/publishingMetrics.html) IAM permission.
 
-It's entrypoint is `handler`, it requires a `go1.x` environment and respects the following env vars:
+It requires a `provided.al2` environment and respects the following env vars:
 
- - `BUILDKITE_BACKEND` : The name of the backend to use (e.g. `cloudwatch`, `statsd`, `prometheus` or `stackdriver`).
- - `BUILDKITE_QUEUE` : A comma separated list of Buildkite queues to process (e.g. `backend-deploy,ui-deploy`).
- - `BUILDKITE_QUIET` : A boolean specifying that only `ERROR` log lines must be printed. (e.g. `1`, `true`).
- - `BUILDKITE_CLOUDWATCH_DIMENSIONS` : A comma separated list in the form of Key=Value, Other=Value containing the Cloudwatch dimensions to index metrics under. 
- 
+- `BUILDKITE_BACKEND` : The name of the backend to use (e.g. `cloudwatch`, `statsd`, `prometheus` or `stackdriver`).
+- `BUILDKITE_QUEUE` : A comma separated list of Buildkite queues to process (e.g. `backend-deploy,ui-deploy`).
+- `BUILDKITE_QUIET` : A boolean specifying that only `ERROR` log lines must be printed. (e.g. `1`, `true`).
+- `BUILDKITE_CLOUDWATCH_DIMENSIONS` : A comma separated list in the form of Key=Value, Other=Value containing the Cloudwatch dimensions to index metrics under.
+
 Additionally, one of the following groups of environment variables must be set in order to define how the Lambda function
 should obtain the required Buildkite Agent API token:
- 
+
 ##### Option 1 - Provide the token as plain-text
-   
+
 - `BUILDKITE_AGENT_TOKEN` : The Buildkite Agent API token to use.
- 
+
 #### Option 2 - Retrieve token from AWS Systems Manager
 
-- `BUILDKITE_AGENT_TOKEN_SSM_KEY` : The parameter name which contains the token value in AWS 
-Systems Manager. 
- 
-**Note**: Parameters stored as `String` and `SecureString` are currently supported. 
+- `BUILDKITE_AGENT_TOKEN_SSM_KEY` : The parameter name which contains the token value in AWS
+Systems Manager.
+
+**Note**: Parameters stored as `String` and `SecureString` are currently supported.
 
 #### Option 3 - Retrieve token from AWS Secrets Manager
 
 - `BUILDKITE_AGENT_SECRETS_MANAGER_SECRET_ID`: The id of the secret which contains the token value
-in AWS Secrets Manager. 
+in AWS Secrets Manager.
 
 - (Optional) `BUILDKITE_AGENT_SECRETS_MANAGER_JSON_KEY`: The JSON key containing the token value in the secret JSON blob.
 
 **Note 1**: Both `SecretBinary` and `SecretString` are supported. In the case of `SecretBinary`, the secret payload will
 be automatically decoded and returned as a plain-text string.
 
-**Note 2**: `BUILDKITE_AGENT_SECRETS_MANAGER_JSON_KEY` can be used on secrets of type `SecretBinary` only if their 
-binary payload corresponds to a valid JSON object containing the provided key. 
+**Note 2**: `BUILDKITE_AGENT_SECRETS_MANAGER_JSON_KEY` can be used on secrets of type `SecretBinary` only if their
+binary payload corresponds to a valid JSON object containing the provided key.
 
 ```bash
 aws lambda create-function \

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"strconv"
@@ -60,7 +60,7 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 	timeout := os.Getenv("BUILDKITE_AGENT_METRICS_TIMEOUT")
 
 	if quiet {
-		log.SetOutput(ioutil.Discard)
+		log.SetOutput(io.Discard)
 	}
 
 	t := time.Now()


### PR DESCRIPTION
I also cleaned up some deprecated code. I tried to use the `static: true` option to the cross compile plugin, but it uses some outdated options to `go build` that did not work on non-linux OSes. So I changed the build step to use the docker plugin and a wrote a script to build and upload the artifact instead.

Fixes: #202