### PR TITLE
Collect from multiple clusters

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 steps:
   - name: ":test_tube: Test"
     key: test
-    command: go test -v -race .
+    command: go test -v -race ./...
     plugins:
       - docker#v5.9.0:
           image: golang:1.21

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Either download the latest binary from
 [Github Releases](https://github.com/buildkite/buildkite-agent-metrics/releases) or install with:
 
 ```bash
-go get github.com/buildkite/buildkite-agent-metrics
+go install github.com/buildkite/buildkite-agent-metrics@latest
 ```
 
 ## Running

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ A command-line tool for collecting [Buildkite](https://buildkite.com/) agent met
 
 [![Build status](https://badge.buildkite.com/80d04fcde3a306bef44e77aadb1f1ffdc20ebb3c8f1f585a60.svg)](https://buildkite.com/buildkite/buildkite-agent-metrics)
 
-
 ## Installing
 
-Either download the latest binary from [Github Releases](https://github.com/buildkite/buildkite-agent-metrics/releases) or install with:
+Either download the latest binary from
+[Github Releases](https://github.com/buildkite/buildkite-agent-metrics/releases) or install with:
 
 ```bash
 go get github.com/buildkite/buildkite-agent-metrics
@@ -15,65 +15,95 @@ go get github.com/buildkite/buildkite-agent-metrics
 
 ## Running
 
-Several running modes are supported. All of them require an Agent Registration Token, found on the [Buildkite Agents page](https://buildkite.com/organizations/-/agents).
+Several running modes are supported. All of them require an Agent Registration
+Token, found on the
+[Buildkite Agents page](https://buildkite.com/organizations/-/agents).
 
 ### Running as a Daemon
 
-The simplest deployment is to run as a long-running daemon that collects metrics across all queues in an organization.
+The simplest deployment is to run as a long-running daemon that collects metrics
+across all queues in an organization.
 
-```
+```shell
 buildkite-agent-metrics -token abc123 -interval 30s
 ```
 
-Restrict it to a single queue with `-queue` if you're scaling a single cluster of agents:
+Restrict it to a single queue with `-queue`:
 
-```
+```shell
 buildkite-agent-metrics -token abc123 -interval 30s -queue my-queue
 ```
 
-Restrict it to a multiple queues with `-queue`:
+Restrict it to multiple queues by repeating `-queue`:
 
-```
+```shell
 buildkite-agent-metrics -token abc123 -interval 30s -queue my-queue1 -queue my-queue2
+```
+
+When using clusters, you can pass a cluster registration token to gather metrics
+only for that cluster:
+
+```shell
+buildkite-agent-metrics -token clustertoken ...
+```
+
+You can repeat `-token` to gather metrics for multiple clusters:
+
+```shell
+buildkite-agent-metrics -token clusterAtoken -token clusterBtoken ...
 ```
 
 ### Running as an AWS Lambda
 
-An AWS Lambda bundle is created and published as part of the build process. The lambda will require the [`cloudwatch:PutMetricData`](https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/publishingMetrics.html) IAM permission.
+An AWS Lambda bundle is created and published as part of the build process. The
+lambda will require the
+[`cloudwatch:PutMetricData`](https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/publishingMetrics.html)
+IAM permission.
 
 It requires a `provided.al2` environment and respects the following env vars:
 
-- `BUILDKITE_BACKEND` : The name of the backend to use (e.g. `cloudwatch`, `statsd`, `prometheus` or `stackdriver`).
-- `BUILDKITE_QUEUE` : A comma separated list of Buildkite queues to process (e.g. `backend-deploy,ui-deploy`).
-- `BUILDKITE_QUIET` : A boolean specifying that only `ERROR` log lines must be printed. (e.g. `1`, `true`).
-- `BUILDKITE_CLOUDWATCH_DIMENSIONS` : A comma separated list in the form of Key=Value, Other=Value containing the Cloudwatch dimensions to index metrics under.
+- `BUILDKITE_BACKEND` : The name of the backend to use (e.g. `cloudwatch`,
+   `statsd`, `newrelic`. For the lambda, `prometheus` and `stackdriver` are not
+   supported).
+- `BUILDKITE_QUEUE` : A comma separated list of Buildkite queues to process
+  (e.g. `backend-deploy,ui-deploy`).
+- `BUILDKITE_QUIET` : A boolean specifying that only `ERROR` log lines must be
+   printed. (e.g. `1`, `true`).
+- `BUILDKITE_CLOUDWATCH_DIMENSIONS` : A comma separated list in the form of
+   `Key=Value,Other=Value` containing the Cloudwatch dimensions to index metrics
+   under.
 
-Additionally, one of the following groups of environment variables must be set in order to define how the Lambda function
-should obtain the required Buildkite Agent API token:
+Additionally, one of the following groups of environment variables must be set
+in order to define how the Lambda function should obtain the required Buildkite
+Agent API token:
 
-##### Option 1 - Provide the token as plain-text
+#### Option 1 - Provide the token(s) as plain-text
 
-- `BUILDKITE_AGENT_TOKEN` : The Buildkite Agent API token to use.
+- `BUILDKITE_AGENT_TOKEN` : The Buildkite Agent API token to use. You can supply
+  multiple tokens comma-separated.
 
 #### Option 2 - Retrieve token from AWS Systems Manager
 
-- `BUILDKITE_AGENT_TOKEN_SSM_KEY` : The parameter name which contains the token value in AWS
-Systems Manager.
+- `BUILDKITE_AGENT_TOKEN_SSM_KEY` : The parameter name which contains the token
+  value in AWS Systems Manager.
 
-**Note**: Parameters stored as `String` and `SecureString` are currently supported.
+**Note**: Parameters stored as `String` and `SecureString` are currently
+supported.
 
 #### Option 3 - Retrieve token from AWS Secrets Manager
 
-- `BUILDKITE_AGENT_SECRETS_MANAGER_SECRET_ID`: The id of the secret which contains the token value
-in AWS Secrets Manager.
+- `BUILDKITE_AGENT_SECRETS_MANAGER_SECRET_ID`: The id of the secret which
+  contains the token value in AWS Secrets Manager.
+- (Optional) `BUILDKITE_AGENT_SECRETS_MANAGER_JSON_KEY`: The JSON key containing
+  the token value in the secret JSON blob.
 
-- (Optional) `BUILDKITE_AGENT_SECRETS_MANAGER_JSON_KEY`: The JSON key containing the token value in the secret JSON blob.
+**Note 1**: Both `SecretBinary` and `SecretString` are supported. In the case of
+`SecretBinary`, the secret payload will be automatically decoded and returned as
+a plain-text string.
 
-**Note 1**: Both `SecretBinary` and `SecretString` are supported. In the case of `SecretBinary`, the secret payload will
-be automatically decoded and returned as a plain-text string.
-
-**Note 2**: `BUILDKITE_AGENT_SECRETS_MANAGER_JSON_KEY` can be used on secrets of type `SecretBinary` only if their
-binary payload corresponds to a valid JSON object containing the provided key.
+**Note 2**: `BUILDKITE_AGENT_SECRETS_MANAGER_JSON_KEY` can be used on secrets of
+type `SecretBinary` only if their binary payload corresponds to a valid JSON
+object containing the provided key.
 
 ```bash
 aws lambda create-function \
@@ -89,20 +119,23 @@ aws lambda create-function \
 
 You can build a docker image for the `buildkite-agent-metrics` following:
 
-```
+```shell
 docker build -t buildkite-agent-metrics .
 ```
 
-This will create a local docker image named as `buildkite-agent-metrics` that you can tag and push to your own registry.
+This will create a local docker image named as `buildkite-agent-metrics` that
+you can tag and push to your own registry.
 
-You can use the command-line arguments in a docker execution in the same way as described before:
+You can use the command-line arguments in a docker execution in the same way as
+described before:
 
-```
+```shell
 docker run --rm buildkite-agent-metrics -token abc123 -interval 30s -queue my-queue
 ```
 
 ### Supported command line flags
-```
+
+```shell
 $ buildkite-agent-metrics --help
 Usage of buildkite-agent-metrics:
   -backend string
@@ -149,48 +182,72 @@ Usage of buildkite-agent-metrics:
 
 By default metrics will be submitted to CloudWatch but the backend can be switched to StatsD or Prometheus using the command-line argument `-backend statsd` or `-backend prometheus` respectively.
 
+#### Cloudwatch
+
 The Cloudwatch backend supports the following arguments:
 
-* `-cloudwatch-dimensions`: A optional custom dimension in the form of `Key=Value, Key=Value`
+- `-cloudwatch-dimensions`: A optional custom dimension in the form of `Key=Value, Key=Value`
+
+#### StatsD (Datadog)
 
 The StatsD backend supports the following arguments:
 
-* `-statsd-host HOST`: The StatsD host and port (defaults to `127.0.0.1:8125`).
-* `-statsd-tags`: Some StatsD servers like the agent provided by Datadog support tags. If specified, metrics will be tagged by `queue` otherwise metrics will include the queue name in the metric. Only enable this option if you know your StatsD server supports tags.
+- `-statsd-host HOST`: The StatsD host and port (defaults to `127.0.0.1:8125`).
+- `-statsd-tags`: Some StatsD servers like the agent provided by Datadog support
+   tags. If specified, metrics will be tagged by `queue` otherwise metrics will
+   include the queue name in the metric. Only enable this option if you know
+   your StatsD server supports tags.
+
+#### Prometheus
 
 The Prometheus backend supports the following arguments:
 
-* `-prometheus-addr`: The local address to listen on (defaults to `:8080`).
-* `-prometheus-path`: The path under `prometheus-addr` to expose metrics on (defaults to `/metrics`).
+- `-prometheus-addr`: The local address to listen on (defaults to `:8080`).
+- `-prometheus-path`: The path under `prometheus-addr` to expose metrics on
+   (defaults to `/metrics`).
+
+#### Stackdriver
 
 The Stackdriver backend supports the following arguments:
 
-* `-stackdriver-projectid`: The Google Cloud Platform project to report metrics for.
+- `-stackdriver-projectid`: The Google Cloud Platform project to report metrics
+   for.
 
 The New Relic backend supports the following arguments:
 
-*   `-newrelic-app-name`: String for the New Relic app name
-*   `-newrelic-license-key`: The New Relic license key. Must be of type `INGEST`
+- `-newrelic-app-name`: String for the New Relic app name
+- `-newrelic-license-key`: The New Relic license key. Must be of type `INGEST`
 
 ### Upgrading from v2 to v3
 
 1. The `-org` argument is no longer needed
-2. The `-token` argument is now an _Agent Registration Token_ — the same used in the Buildkite Agent configuration file, and found on the [Buildkite Agents page](https://buildkite.com/organizations/-/agents).
-3. Build and pipeline metrics have been removed, focusing on agents and jobs by queue for auto–scaling.
-   If you have a compelling reason to gather build or pipeline metrics please continue to use the [previous version](https://github.com/buildkite/buildkite-agent-metrics/releases/tag/v2.1.0) or [open an issue](https://github.com/buildkite/buildkite-agent-metrics/issues) with details.
+2. The `-token` argument is now an _Agent Registration Token_ — the same used in
+   the Buildkite Agent configuration file, and found on the
+   [Buildkite Agents page](https://buildkite.com/organizations/-/agents).
+3. Build and pipeline metrics have been removed, focusing on agents and jobs by
+   queue for auto–scaling.
+   If you have a compelling reason to gather build or pipeline metrics please
+   continue to use the
+   [previous version](https://github.com/buildkite/buildkite-agent-metrics/releases/tag/v2.1.0)
+   or [open an issue](https://github.com/buildkite/buildkite-agent-metrics/issues)
+   with details.
 
 ## Development
 
-This tool is built with Go 1.11+ and [Go Modules](https://github.com/golang/go/wiki/Modules).
+This tool is built with Go 1.20+ and assumes
+[Go Modules](https://github.com/golang/go/wiki/Modules) by default.
 
-You can build and run the binary tool locally with golang installed:
+You can build and run the binary tool locally with Go installed:
 
-```
-export GO111MODULE=on
+```shell
 go run *.go -token [buildkite agent registration token]
 ```
 
-Currently this will publish metrics to Cloudwatch under the custom metric prefix of `Buildkite`, using AWS credentials from your environment. The machine will require the [`cloudwatch:PutMetricData`](https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/publishingMetrics.html) IAM permission.
+Currently this will publish metrics to Cloudwatch under the custom metric prefix
+of `Buildkite`, using AWS credentials from your environment. The machine will
+require the
+[`cloudwatch:PutMetricData`](https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/publishingMetrics.html)
+IAM permission.
 
 ### The `token` package
 
@@ -217,7 +274,7 @@ go generate token/ssm_test.go
 
 The following metrics are gathered when no specific queue is supplied:
 
-```
+```plain
 Buildkite > (Org) > RunningJobsCount
 Buildkite > (Org) > ScheduledJobsCount
 Buildkite > (Org) > UnfinishedJobsCount
@@ -240,9 +297,13 @@ Buildkite > (Org, Queue) > TotalAgentsCount
 When a queue is specified, only that queue's metrics are published.
 
 We send metrics for Jobs in the following states:
-* **Scheduled**, the job hasn't been assigned to an agent yet. If you have agent capacity, this value should be close to 0.
-* **Waiting**, the job is known to exist but isn't schedulable yet due to dependencies, `wait` statements, etc. This information is mostly useful to an autoscaler, since it represents work that will start soon.
-* **Running**, an agent is actively executing this job.
+
+- **Scheduled**: the job hasn't been assigned to an agent yet. If you have agent
+  capacity, this value should be close to 0.
+- **Waiting**: the job is known to exist but isn't schedulable yet due to
+  dependencies, `wait` statements, etc. This information is mostly useful to an
+  autoscaler, since it represents work that will start soon.
+- **Running**: an agent is actively executing this job.
 
 ## License
 

--- a/backend/cloudwatch.go
+++ b/backend/cloudwatch.go
@@ -65,7 +65,14 @@ func (cb *CloudWatchBackend) Collect(r *collector.Result) error {
 
 	// Set the baseline org dimension
 	dimensions := []*cloudwatch.Dimension{
-		&cloudwatch.Dimension{Name: aws.String("Org"), Value: aws.String(r.Org)},
+		{
+			Name:  aws.String("Org"),
+			Value: aws.String(r.Org),
+		},
+		{
+			Name:  aws.String("Cluster"),
+			Value: aws.String(r.Cluster),
+		},
 	}
 
 	// Add custom dimension if provided

--- a/backend/newrelic.go
+++ b/backend/newrelic.go
@@ -40,8 +40,8 @@ func NewNewRelicBackend(appName string, licenseKey string) (*NewRelicBackend, er
 // Collect metrics
 func (nr *NewRelicBackend) Collect(r *collector.Result) error {
 	// Publish event for each queue
-	for name, c := range r.Queues {
-		data := toCustomEvent(name, c)
+	for queue, metrics := range r.Queues {
+		data := toCustomEvent(r.Cluster, queue, metrics)
 		err := nr.client.RecordCustomEvent("BuildkiteQueueMetrics", data)
 		if err != nil {
 			return err
@@ -54,9 +54,10 @@ func (nr *NewRelicBackend) Collect(r *collector.Result) error {
 }
 
 // toCustomEvent converts a map of metrics to a valid New Relic event body
-func toCustomEvent(queueName string, queueMetrics map[string]int) map[string]interface{} {
-	eventData := map[string]interface{}{
-		"Queue": queueName,
+func toCustomEvent(clusterName, queueName string, queueMetrics map[string]int) map[string]any {
+	eventData := map[string]any{
+		"Cluster": clusterName,
+		"Queue":   queueName,
 	}
 
 	for k, v := range queueMetrics {

--- a/backend/prometheus.go
+++ b/backend/prometheus.go
@@ -23,21 +23,19 @@ type Prometheus struct {
 	pipelines map[string]*prometheus.GaugeVec
 }
 
-func NewPrometheusBackend(path, addr string) *Prometheus {
-	go func() {
-		http.Handle(path, promhttp.Handler())
-		log.Fatal(http.ListenAndServe(addr, nil))
-	}()
-
-	return newPrometheus()
-}
-
-func newPrometheus() *Prometheus {
+func NewPrometheusBackend() *Prometheus {
 	return &Prometheus{
 		totals:    make(map[string]prometheus.Gauge),
 		queues:    make(map[string]*prometheus.GaugeVec),
 		pipelines: make(map[string]*prometheus.GaugeVec),
 	}
+}
+
+// Serve runs a Prometheus metrics HTTP server.
+func (p *Prometheus) Serve(path, addr string) {
+	m := http.NewServeMux()
+	m.Handle(path, promhttp.Handler())
+	log.Fatal(http.ListenAndServe(addr, m))
 }
 
 func (p *Prometheus) Collect(r *collector.Result) error {

--- a/backend/prometheus_test.go
+++ b/backend/prometheus_test.go
@@ -5,12 +5,12 @@ import (
 	"testing"
 
 	"github.com/buildkite/buildkite-agent-metrics/collector"
+	"github.com/google/go-cmp/cmp"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 )
 
 const (
-	wantHaveFmt        = "want %v, have %v"
 	runningBuildsCount = iota
 	scheduledBuildsCount
 	runningJobsCount
@@ -35,7 +35,8 @@ func newTestResult(t *testing.T) *collector.Result {
 	}
 
 	res := &collector.Result{
-		Totals: totals,
+		Totals:  totals,
+		Cluster: "test_cluster",
 		Queues: map[string]map[string]int{
 			"default": totals,
 			"deploy":  totals,
@@ -44,6 +45,8 @@ func newTestResult(t *testing.T) *collector.Result {
 	return res
 }
 
+// gatherMetrics runs the Prometheus gatherer, and returns the metric families
+// grouped by name.
 func gatherMetrics(t *testing.T) map[string]*dto.MetricFamily {
 	t.Helper()
 
@@ -57,112 +60,166 @@ func gatherMetrics(t *testing.T) map[string]*dto.MetricFamily {
 	p := NewPrometheusBackend()
 	p.Collect(newTestResult(t))
 
-	if mfs, err := r.Gather(); err != nil {
-		t.Fatal(err)
+	mfs, err := r.Gather()
+	if err != nil {
+		t.Fatalf("prometheus.Registry.Gather() = %v", err)
 		return nil
-	} else {
-		mfsm := make(map[string]*dto.MetricFamily)
-		for _, mf := range mfs {
-			mfsm[*mf.Name] = mf
-		}
-		return mfsm
 	}
+
+	mfsm := make(map[string]*dto.MetricFamily)
+	for _, mf := range mfs {
+		mfsm[*mf.Name] = mf
+	}
+	return mfsm
 }
 
 func TestCollect(t *testing.T) {
-	mfs := gatherMetrics(t)
+	metricFamilies := gatherMetrics(t)
 
-	if want, have := 16, len(mfs); want != have {
-		t.Errorf("wanted %d Prometheus metrics, have: %d", want, have)
+	if got, want := len(metricFamilies), 16; got != want {
+		t.Errorf("len(metricFamilies) = %d, want %d", got, want)
+	}
+
+	type promMetric struct {
+		Labels map[string]string
+		Value  float64
 	}
 
 	tcs := []struct {
-		Group      string
-		PromName   string
-		PromHelp   string
-		PromLabels []string
-		PromValue  float64
-		PromType   dto.MetricType
+		group       string
+		metricName  string
+		wantHelp    string
+		wantType    dto.MetricType
+		wantMetrics []promMetric
 	}{
 		{
-			"Total",
-			"buildkite_total_running_jobs_count",
-			"Buildkite Total: RunningJobsCount",
-			[]string{},
-			runningJobsCount,
-			dto.MetricType_GAUGE,
+			group:      "Total",
+			metricName: "buildkite_total_running_jobs_count",
+			wantHelp:   "Buildkite Total: RunningJobsCount",
+			wantType:   dto.MetricType_GAUGE,
+			wantMetrics: []promMetric{
+				{
+					Labels: map[string]string{"cluster": "test_cluster"},
+					Value:  runningJobsCount,
+				},
+			},
 		},
 		{
-			"Total",
-			"buildkite_total_scheduled_jobs_count",
-			"Buildkite Total: ScheduledJobsCount",
-			[]string{},
-			scheduledJobsCount,
-			dto.MetricType_GAUGE,
+			group:      "Total",
+			metricName: "buildkite_total_scheduled_jobs_count",
+			wantHelp:   "Buildkite Total: ScheduledJobsCount",
+			wantType:   dto.MetricType_GAUGE,
+			wantMetrics: []promMetric{
+				{
+					Labels: map[string]string{"cluster": "test_cluster"},
+					Value:  scheduledJobsCount,
+				},
+			},
 		},
 		{
-			"Queues",
-			"buildkite_queues_scheduled_builds_count",
-			"Buildkite Queues: ScheduledBuildsCount",
-			[]string{"default", "deploy"},
-			scheduledBuildsCount,
-			dto.MetricType_GAUGE,
+			group:      "Queues",
+			metricName: "buildkite_queues_scheduled_builds_count",
+			wantHelp:   "Buildkite Queues: ScheduledBuildsCount",
+			wantType:   dto.MetricType_GAUGE,
+			wantMetrics: []promMetric{
+				{
+					Labels: map[string]string{
+						"cluster": "test_cluster",
+						"queue":   "default",
+					},
+					Value: scheduledBuildsCount,
+				},
+				{
+					Labels: map[string]string{
+						"cluster": "test_cluster",
+						"queue":   "deploy",
+					},
+					Value: scheduledBuildsCount,
+				},
+			},
 		},
 		{
-			"Queues",
-			"buildkite_queues_idle_agent_count",
-			"Buildkite Queues: IdleAgentCount",
-			[]string{"default", "deploy"},
-			idleAgentCount,
-			dto.MetricType_GAUGE,
+			group:      "Queues",
+			metricName: "buildkite_queues_idle_agent_count",
+			wantHelp:   "Buildkite Queues: IdleAgentCount",
+			wantType:   dto.MetricType_GAUGE,
+			wantMetrics: []promMetric{
+				{
+					Labels: map[string]string{
+						"cluster": "test_cluster",
+						"queue":   "default",
+					},
+					Value: idleAgentCount,
+				},
+				{
+					Labels: map[string]string{
+						"cluster": "test_cluster",
+						"queue":   "deploy",
+					},
+					Value: idleAgentCount,
+				},
+			},
 		},
 	}
 
 	for _, tc := range tcs {
-		t.Run(fmt.Sprintf("%s/%s", tc.Group, tc.PromName), func(t *testing.T) {
-			mf, ok := mfs[tc.PromName]
+		t.Run(fmt.Sprintf("%s/%s", tc.group, tc.metricName), func(t *testing.T) {
+			mf, ok := metricFamilies[tc.metricName]
 			if !ok {
-				t.Errorf("no metric found for name %s", tc.PromName)
+				t.Errorf("no metric found for name %s", tc.metricName)
 			}
 
-			if want, have := tc.PromHelp, mf.GetHelp(); want != have {
-				t.Errorf(wantHaveFmt, want, have)
+			if got, want := mf.GetHelp(), tc.wantHelp; got != want {
+				t.Errorf("mf.GetHelp() = %q, want %q", got, want)
 			}
 
-			if want, have := tc.PromType, mf.GetType(); want != have {
-				t.Errorf(wantHaveFmt, want, have)
+			if got, want := mf.GetType(), tc.wantType; got != want {
+				t.Errorf("mf.GetType() = %q, want %q", got, want)
 			}
 
+			// Convert the metric family into an easier-to-diff form.
 			ms := mf.GetMetric()
-			for i, m := range ms {
-				if want, have := tc.PromValue, m.GetGauge().GetValue(); want != have {
-					t.Errorf(wantHaveFmt, want, have)
+			var gotMetrics []promMetric
+			for _, m := range ms {
+				gotMetric := promMetric{
+					Value:  m.Gauge.GetValue(),
+					Labels: make(map[string]string),
 				}
-
-				if len(tc.PromLabels) > 0 {
-					if want, have := tc.PromLabels[i], m.Label[0].GetValue(); want != have {
-						t.Errorf(wantHaveFmt, want, have)
-					}
+				for _, label := range m.Label {
+					gotMetric.Labels[label.GetName()] = label.GetValue()
 				}
+				gotMetrics = append(gotMetrics, gotMetric)
 			}
 
+			if diff := cmp.Diff(gotMetrics, tc.wantMetrics); diff != "" {
+				t.Errorf("metrics diff (-got +want):\n%s", diff)
+			}
 		})
 	}
 }
 
 func TestCamelToUnderscore(t *testing.T) {
 	tcs := []struct {
-		Camel      string
-		Underscore string
+		input string
+		want  string
 	}{
-		{"TotalAgentCount", "total_agent_count"},
-		{"Total@#4JobsCount", "total@#4_jobs_count"},
-		{"BuildkiteQueuesIdleAgentCount1_11", "buildkite_queues_idle_agent_count1_11"},
+		{
+			input: "TotalAgentCount",
+			want:  "total_agent_count",
+		},
+		{
+			input: "Total@#4JobsCount",
+			want:  "total@#4_jobs_count",
+		},
+		{
+			input: "BuildkiteQueuesIdleAgentCount1_11",
+			want:  "buildkite_queues_idle_agent_count1_11",
+		},
 	}
 
 	for _, tc := range tcs {
-		if want, have := tc.Underscore, camelToUnderscore(tc.Camel); want != have {
-			t.Errorf(wantHaveFmt, want, have)
+		if got := camelToUnderscore(tc.input); got != tc.want {
+			t.Errorf("camelToUnderscore(%q) = %q, want %q", tc.input, got, tc.want)
 		}
 	}
 }

--- a/backend/prometheus_test.go
+++ b/backend/prometheus_test.go
@@ -54,7 +54,7 @@ func gatherMetrics(t *testing.T) map[string]*dto.MetricFamily {
 	r := prometheus.NewRegistry()
 	prometheus.DefaultRegisterer = r
 
-	p := newPrometheus()
+	p := NewPrometheusBackend()
 	p.Collect(newTestResult(t))
 
 	if mfs, err := r.Gather(); err != nil {

--- a/backend/stackdriver.go
+++ b/backend/stackdriver.go
@@ -11,9 +11,9 @@ import (
 	"google.golang.org/genproto/googleapis/api/label"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	monitoring "cloud.google.com/go/monitoring/apiv3"
+	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
+	"cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
 	"google.golang.org/genproto/googleapis/api/metric"
-	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
 )
 
 const (

--- a/backend/stackdriver.go
+++ b/backend/stackdriver.go
@@ -17,10 +17,12 @@ import (
 )
 
 const (
-	metricName        = "custom.googleapis.com/buildkite/%s/%s"
-	queueLabelKey     = "Queue"
-	queueDescription  = "Queue Descriptor"
-	totalMetricsQueue = "Total"
+	metricTypeFmt      = "custom.googleapis.com/buildkite/%s/%s"
+	clusterLabelKey    = "Cluster"
+	clusterDescription = "Name of the Buildkite Cluster, or empty"
+	queueLabelKey      = "Queue"
+	queueDescription   = "Name of the Queue"
+	totalMetricsQueue  = "Total"
 )
 
 // Stackdriver does not allow dashes in metric names
@@ -55,10 +57,14 @@ func (sd *StackDriverBackend) Collect(r *collector.Result) error {
 		Seconds: time.Now().Unix(),
 	}
 	orgName := dashReplacer.Replace(r.Org)
+	metricTypeFunc := func(name string) string {
+		return fmt.Sprintf(metricTypeFmt, orgName, name)
+	}
+
 	for name, value := range r.Totals {
 		mt, present := sd.metricTypes[name]
 		if !present {
-			mt = fmt.Sprintf(metricName, orgName, name)
+			mt = metricTypeFunc(name)
 			metricReq := createCustomMetricRequest(&sd.projectID, &mt)
 			_, err := sd.client.CreateMetricDescriptor(ctx, metricReq)
 			if err != nil {
@@ -69,7 +75,7 @@ func (sd *StackDriverBackend) Collect(r *collector.Result) error {
 			log.Printf("[Collect] created custom metric [%s]", mt)
 			sd.metricTypes[name] = mt
 		}
-		req := createTimeSeriesValueRequest(&sd.projectID, &mt, totalMetricsQueue, value, now)
+		req := createTimeSeriesValueRequest(&sd.projectID, &mt, r.Cluster, totalMetricsQueue, value, now)
 		err := sd.client.CreateTimeSeries(ctx, req)
 		if err != nil {
 			retErr := fmt.Errorf("[Collect] could not write metric [%s] value [%d], %v ", mt, value, err)
@@ -80,8 +86,8 @@ func (sd *StackDriverBackend) Collect(r *collector.Result) error {
 
 	for queue, counts := range r.Queues {
 		for name, value := range counts {
-			mt := fmt.Sprintf(metricName, orgName, name)
-			req := createTimeSeriesValueRequest(&sd.projectID, &mt, queue, value, now)
+			mt := metricTypeFunc(name)
+			req := createTimeSeriesValueRequest(&sd.projectID, &mt, r.Cluster, queue, value, now)
 			err := sd.client.CreateTimeSeries(ctx, req)
 			if err != nil {
 				retErr := fmt.Errorf("[Collect] could not write metric [%s] value [%d], %v ", mt, value, err)
@@ -96,12 +102,20 @@ func (sd *StackDriverBackend) Collect(r *collector.Result) error {
 
 // createCustomMetricRequest creates a custom metric request as specified by the metric type.
 func createCustomMetricRequest(projectID *string, metricType *string) *monitoringpb.CreateMetricDescriptorRequest {
-	l := &label.LabelDescriptor{
+	clusterLabel := &label.LabelDescriptor{
+		Key:         clusterLabelKey,
+		ValueType:   label.LabelDescriptor_STRING,
+		Description: clusterDescription,
+	}
+	queueLabel := &label.LabelDescriptor{
 		Key:         queueLabelKey,
 		ValueType:   label.LabelDescriptor_STRING,
 		Description: queueDescription,
 	}
-	labels := []*label.LabelDescriptor{l}
+	labels := []*label.LabelDescriptor{
+		clusterLabel,
+		queueLabel,
+	}
 	md := &metric.MetricDescriptor{
 		Name:        *metricType,
 		Type:        *metricType,
@@ -120,13 +134,16 @@ func createCustomMetricRequest(projectID *string, metricType *string) *monitorin
 }
 
 // createTimeSeriesValueRequest creates a StackDriver value request for the specified metric
-func createTimeSeriesValueRequest(projectID *string, metricType *string, queue string, value int, time *timestamppb.Timestamp) *monitoringpb.CreateTimeSeriesRequest {
+func createTimeSeriesValueRequest(projectID *string, metricType *string, cluster, queue string, value int, time *timestamppb.Timestamp) *monitoringpb.CreateTimeSeriesRequest {
 	req := &monitoringpb.CreateTimeSeriesRequest{
 		Name: "projects/" + *projectID,
 		TimeSeries: []*monitoringpb.TimeSeries{{
 			Metric: &metric.Metric{
-				Type:   *metricType,
-				Labels: map[string]string{queueLabelKey: queue},
+				Type: *metricType,
+				Labels: map[string]string{
+					clusterLabelKey: cluster,
+					queueLabelKey:   queue,
+				},
 			},
 			Points: []*monitoringpb.Point{{
 				Interval: &monitoringpb.TimeInterval{

--- a/backend/stackdriver_test.go
+++ b/backend/stackdriver_test.go
@@ -1,14 +1,14 @@
 package backend
 
 import (
-	"fmt"
-	"reflect"
 	"testing"
 	"time"
 
+	"cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
+	"github.com/google/go-cmp/cmp"
 	"google.golang.org/genproto/googleapis/api/label"
 	"google.golang.org/genproto/googleapis/api/metric"
-	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
+	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -22,62 +22,89 @@ func Test_createCustomMetricRequest(t *testing.T) {
 		args args
 		want *monitoringpb.CreateMetricDescriptorRequest
 	}{
-		{name: "HappyPath", args: args{projectID: "test-project-id", metricType: "test-metric-type"}, want: &monitoringpb.CreateMetricDescriptorRequest{
-			Name: "projects/test-project-id",
-			MetricDescriptor: &metric.MetricDescriptor{
-				Name:        "test-metric-type",
-				Type:        "test-metric-type",
-				MetricKind:  metric.MetricDescriptor_GAUGE,
-				ValueType:   metric.MetricDescriptor_INT64,
-				Description: fmt.Sprintf("Buildkite metric: [test-metric-type]"),
-				DisplayName: "test-metric-type",
-				Labels: []*label.LabelDescriptor{{
-					Key:         queueLabelKey,
-					ValueType:   label.LabelDescriptor_STRING,
-					Description: queueDescription,
-				}},
+		{
+			name: "HappyPath",
+			args: args{
+				projectID:  "test-project-id",
+				metricType: "test-metric-type",
 			},
-		}},
+			want: &monitoringpb.CreateMetricDescriptorRequest{
+				Name: "projects/test-project-id",
+				MetricDescriptor: &metric.MetricDescriptor{
+					Name:        "test-metric-type",
+					Type:        "test-metric-type",
+					MetricKind:  metric.MetricDescriptor_GAUGE,
+					ValueType:   metric.MetricDescriptor_INT64,
+					Description: "Buildkite metric: [test-metric-type]",
+					DisplayName: "test-metric-type",
+					Labels: []*label.LabelDescriptor{
+						{
+							Key:         clusterLabelKey,
+							ValueType:   label.LabelDescriptor_STRING,
+							Description: clusterDescription,
+						},
+						{
+							Key:         queueLabelKey,
+							ValueType:   label.LabelDescriptor_STRING,
+							Description: queueDescription,
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := createCustomMetricRequest(&tt.args.projectID, &tt.args.metricType); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("createCustomMetricRequest() = %v, want %v", got, tt.want)
+			got := createCustomMetricRequest(&tt.args.projectID, &tt.args.metricType)
+			if diff := cmp.Diff(got, tt.want, protocmp.Transform()); diff != "" {
+				t.Errorf("createCustomMetricRequest diff (-got +want):\n%s", diff)
 			}
 		})
 	}
 }
 
 func Test_createTimeSeriesValueRequest(t *testing.T) {
-	now := timestamppb.Timestamp{
+	now := &timestamppb.Timestamp{
 		Seconds: time.Now().Unix(),
 	}
 
 	type args struct {
 		projectID  string
 		metricType string
+		cluster    string
 		queue      string
 		value      int
-		time       timestamppb.Timestamp
+		time       *timestamppb.Timestamp
 	}
 	tests := []struct {
 		name string
 		args args
 		want *monitoringpb.CreateTimeSeriesRequest
 	}{
-		{name: "Happy Path",
-			args: args{projectID: "test-project-id", metricType: "test-metric-type", queue: "test-queue", value: 13, time: now},
+		{
+			name: "Happy Path",
+			args: args{
+				projectID:  "test-project-id",
+				metricType: "test-metric-type",
+				cluster:    "test-cluster",
+				queue:      "test-queue",
+				value:      13,
+				time:       now,
+			},
 			want: &monitoringpb.CreateTimeSeriesRequest{
 				Name: "projects/test-project-id",
 				TimeSeries: []*monitoringpb.TimeSeries{{
 					Metric: &metric.Metric{
-						Type:   "test-metric-type",
-						Labels: map[string]string{queueLabelKey: "test-queue"},
+						Type: "test-metric-type",
+						Labels: map[string]string{
+							clusterLabelKey: "test-cluster",
+							queueLabelKey:   "test-queue",
+						},
 					},
 					Points: []*monitoringpb.Point{{
 						Interval: &monitoringpb.TimeInterval{
-							StartTime: &now,
-							EndTime:   &now,
+							StartTime: now,
+							EndTime:   now,
 						},
 						Value: &monitoringpb.TypedValue{
 							Value: &monitoringpb.TypedValue_Int64Value{
@@ -88,19 +115,29 @@ func Test_createTimeSeriesValueRequest(t *testing.T) {
 				}},
 			},
 		},
-		{name: "Bad Queue Name",
-			args: args{projectID: "test-project-id", metricType: "test-metric-type", queue: "${BUILDKITE_QUEUE:-default}", value: 13, time: now},
+		{
+			name: "Bad Queue Name",
+			args: args{
+				projectID:  "test-project-id",
+				metricType: "test-metric-type",
+				queue:      "${BUILDKITE_QUEUE:-default}",
+				value:      13,
+				time:       now,
+			},
 			want: &monitoringpb.CreateTimeSeriesRequest{
 				Name: "projects/test-project-id",
 				TimeSeries: []*monitoringpb.TimeSeries{{
 					Metric: &metric.Metric{
-						Type:   "test-metric-type",
-						Labels: map[string]string{queueLabelKey: "${BUILDKITE_QUEUE:-default}"},
+						Type: "test-metric-type",
+						Labels: map[string]string{
+							clusterLabelKey: "",
+							queueLabelKey:   "${BUILDKITE_QUEUE:-default}",
+						},
 					},
 					Points: []*monitoringpb.Point{{
 						Interval: &monitoringpb.TimeInterval{
-							StartTime: &now,
-							EndTime:   &now,
+							StartTime: now,
+							EndTime:   now,
 						},
 						Value: &monitoringpb.TypedValue{
 							Value: &monitoringpb.TypedValue_Int64Value{
@@ -114,8 +151,9 @@ func Test_createTimeSeriesValueRequest(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := createTimeSeriesValueRequest(&tt.args.projectID, &tt.args.metricType, tt.args.queue, tt.args.value, &tt.args.time); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("createTimeSeriesValueRequest() = %v, want %v", got, tt.want)
+			got := createTimeSeriesValueRequest(&tt.args.projectID, &tt.args.metricType, tt.args.cluster, tt.args.queue, tt.args.value, tt.args.time)
+			if diff := cmp.Diff(got, tt.want, protocmp.Transform()); diff != "" {
+				t.Errorf("createTimeSeriesValueRequest diff (-got +want):\n%s", diff)
 			}
 		})
 	}

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -45,11 +45,16 @@ type Result struct {
 	Totals       map[string]int
 	Queues       map[string]map[string]int
 	Org          string
+	Cluster      string
 	PollDuration time.Duration
 }
 
 type organizationResponse struct {
 	Slug string `json:"slug"`
+}
+
+type clusterResponse struct {
+	Name string `json:"name"`
 }
 
 type metricsAgentsResponse struct {
@@ -69,6 +74,7 @@ type queueMetricsResponse struct {
 	Agents       metricsAgentsResponse `json:"agents"`
 	Jobs         metricsJobsResponse   `json:"jobs"`
 	Organization organizationResponse  `json:"organization"`
+	Cluster      clusterResponse       `json:"cluster"`
 }
 
 type allMetricsAgentsResponse struct {
@@ -85,6 +91,7 @@ type allMetricsResponse struct {
 	Agents       allMetricsAgentsResponse `json:"agents"`
 	Jobs         allMetricsJobsResponse   `json:"jobs"`
 	Organization organizationResponse     `json:"organization"`
+	Cluster      clusterResponse          `json:"cluster"`
 }
 
 func (c *Collector) Collect() (*Result, error) {
@@ -195,8 +202,9 @@ func (c *Collector) collectAllQueues(httpClient *http.Client, result *Result) er
 		return fmt.Errorf("No organization slug was found in the metrics response")
 	}
 
-	log.Printf("Found organization %q", allMetrics.Organization.Slug)
+	log.Printf("Found organization %q, cluster %q", allMetrics.Organization.Slug, allMetrics.Cluster.Name)
 	result.Org = allMetrics.Organization.Slug
+	result.Cluster = allMetrics.Cluster.Name
 
 	result.Totals[ScheduledJobsCount] = allMetrics.Jobs.Scheduled
 	result.Totals[RunningJobsCount] = allMetrics.Jobs.Running
@@ -299,8 +307,9 @@ func (c *Collector) collectQueue(httpClient *http.Client, result *Result, queue 
 		return fmt.Errorf("No organization slug was found in the metrics response")
 	}
 
-	log.Printf("Found organization %q", queueMetrics.Organization.Slug)
+	log.Printf("Found organization %q, cluster %q", queueMetrics.Organization.Slug, queueMetrics.Cluster.Name)
 	result.Org = queueMetrics.Organization.Slug
+	result.Cluster = queueMetrics.Cluster.Name
 
 	result.Queues[queue] = map[string]int{
 		ScheduledJobsCount:  queueMetrics.Jobs.Scheduled,

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -202,7 +202,7 @@ func TestCollectorWithSomeJobsAndAgentsForAllQueues(t *testing.T) {
 		{"Queue.deploy", res.Queues["deploy"], IdleAgentCount, 0},
 	}
 
-	for queue, _ := range res.Queues {
+	for queue := range res.Queues {
 		switch queue {
 		case "default", "deploy":
 			continue

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,7 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
@@ -57,6 +58,7 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/s2a-go v0.1.7 h1:60BLSyTrOV4/haCDW4zb1guZItoSq8foHCXrAnjBo/o=
 github.com/google/s2a-go v0.1.7/go.mod h1:50CgR4k1jNlWBu4UfS4AcfhVe1r6pdZPygJ3R8F0Qdw=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -68,8 +70,14 @@ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9Y
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
+github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/newrelic/go-agent v3.24.1+incompatible h1:Dvt6dtEafdrNydNsEHbtSMljWUt8pyWmcaO/wVJmuf8=
 github.com/newrelic/go-agent v3.24.1+incompatible/go.mod h1:a8Fv1b/fYhFSReoTU6HDkTYIMZeSVNffmoS726Y0LzQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -193,6 +201,7 @@ google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqw
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -119,6 +119,7 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 		if err != nil {
 			return "", err
 		}
+
 	case "newrelic":
 		nrAppName := os.Getenv("NEWRELIC_APP_NAME")
 		nrLicenseKey := os.Getenv("NEWRELIC_LICENSE_KEY")
@@ -127,6 +128,7 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 			fmt.Printf("Error starting New Relic client: %v\n", err)
 			os.Exit(1)
 		}
+
 	default:
 		dimensions, err := backend.ParseCloudWatchDimensions(clwDimensions)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ func main() {
 		timeout     = flag.Int("timeout", 15, "Timeout, in seconds, for HTTP requests to Buildkite API")
 
 		// backend config
-		backendOpt     = flag.String("backend", "cloudwatch", "Specify the backend to use: cloudwatch, statsd, prometheus, stackdriver")
+		backendOpt     = flag.String("backend", "cloudwatch", "Specify the backend to use: cloudwatch, newrelic, prometheus, stackdriver, statsd")
 		statsdHost     = flag.String("statsd-host", "127.0.0.1:8125", "Specify the StatsD server")
 		statsdTags     = flag.Bool("statsd-tags", false, "Whether your StatsD server supports tagging like Datadog")
 		prometheusAddr = flag.String("prometheus-addr", ":8080", "Prometheus metrics transport bind address")
@@ -85,16 +85,19 @@ func main() {
 			os.Exit(1)
 		}
 		metricsBackend = backend.NewCloudWatchBackend(region, dimensions)
+
 	case "statsd":
 		metricsBackend, err = backend.NewStatsDBackend(*statsdHost, *statsdTags)
 		if err != nil {
 			fmt.Printf("Error starting StatsD, err: %v\n", err)
 			os.Exit(1)
 		}
+
 	case "prometheus":
 		prom := backend.NewPrometheusBackend()
 		go prom.Serve(*prometheusPath, *prometheusAddr)
 		metricsBackend = prom
+
 	case "stackdriver":
 		if *gcpProjectID == "" {
 			*gcpProjectID = os.Getenv(`GCP_PROJECT_ID`)
@@ -104,14 +107,16 @@ func main() {
 			fmt.Printf("Error starting Stackdriver backend, err: %v\n", err)
 			os.Exit(1)
 		}
+
 	case "newrelic":
 		metricsBackend, err = backend.NewNewRelicBackend(*nrAppName, *nrLicenseKey)
 		if err != nil {
 			fmt.Printf("Error starting New Relic client: %v\n", err)
 			os.Exit(1)
 		}
+
 	default:
-		fmt.Println("Must provide a supported backend: cloudwatch, statsd, prometheus, stackdriver, newrelic")
+		fmt.Println("Must provide a supported backend: cloudwatch, newrelic, prometheus, stackdriver, statsd")
 		os.Exit(1)
 	}
 

--- a/main.go
+++ b/main.go
@@ -92,7 +92,9 @@ func main() {
 			os.Exit(1)
 		}
 	case "prometheus":
-		metricsBackend = backend.NewPrometheusBackend(*prometheusPath, *prometheusAddr)
+		prom := backend.NewPrometheusBackend()
+		go prom.Serve(*prometheusPath, *prometheusAddr)
+		metricsBackend = prom
 	case "stackdriver":
 		if *gcpProjectID == "" {
 			*gcpProjectID = os.Getenv(`GCP_PROJECT_ID`)


### PR DESCRIPTION
There's a lot going on here, which I don't like doing, but I tried to keep the various commits separate.

### Support collecting with multiple tokens

Arguably we should have a single API token that does a single request (like GraphQL), but... not today.

Since this is a loop that produces multiple results, the cluster name from the response occupies a new field in the collector result. One wrinkle is `minPollTime`; I've chosen to use the maximum from the responses.

### Represent cluster in the various backends

Cluster neatly fits as a label / dimension / tag, where supported. I'm not sure whether Cloudwatch or StatsD are correct since the tests are sparse / non existent. Also, the StatsD backend must work with and without tag support, so (after splitting the method) I copied what the existing code did to distinguish queue metrics from totals.

Assuming it all works, I think the main risk is that metric name changes might cause confusion (if anyone is already using cluster tokens).

### Various cleanups

- Removed unnecessary _
- Variable renaming for readability (e.g. b and bk are now `metricsBackend`)
- The ioutil deprecation
- Migrated from deprecated monitoringpb in Stackdriver backend
- Lots of stuff in prometheus_test.go (it's got/want, not want/have, and the way labels were tested before was strange)
- Also, it should be `go test ./...`, not `go test .` 🫠

Fixes #224 