### PR TITLE
Support for multiple secrets manager secrets 

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ supported.
 #### Option 3 - Retrieve token from AWS Secrets Manager
 
 - `BUILDKITE_AGENT_SECRETS_MANAGER_SECRET_ID`: The id of the secret which
-  contains the token value in AWS Secrets Manager.
+  contains the token value in AWS Secrets Manager. You can supply
+  multiple secrets comma-separated.
 - (Optional) `BUILDKITE_AGENT_SECRETS_MANAGER_JSON_KEY`: The JSON key containing
   the token value in the secret JSON blob.
 


### PR DESCRIPTION
## Context
https://github.com/buildkite/buildkite-agent-metrics/pull/227 added support for Clusters (@DrJosh9000), with agent registration tokens provided as a comma separated list.

The assumption for secrets manager secrets was that it would be a single secret with a comma separated list of values. This is not ideal, as it means a new secret needs to be created just for this lambda. If instead a comma separated list of secrets is used, we can keep the registration tokens in their own secrets which is referenced in multiple places.

## Change
This PR supports multiple secrets provided to `BUILDKITE_AGENT_SECRETS_MANAGER_SECRET_ID` (comma-seperated) and queries secrets manager for each value.

## Testing
I've built the lambda zip locally and tested on AWS with 2 agent registration tokens across 2 clusters.
