### PR TITLE
Ignore cluster if it is empty

### DIFF
--- a/backend/cloudwatch.go
+++ b/backend/cloudwatch.go
@@ -69,10 +69,14 @@ func (cb *CloudWatchBackend) Collect(r *collector.Result) error {
 			Name:  aws.String("Org"),
 			Value: aws.String(r.Org),
 		},
-		{
+	}
+
+	// Add cluster dimension if a cluster token was used
+	if r.Cluster != "" {
+		dimensions = append(dimensions, &cloudwatch.Dimension{
 			Name:  aws.String("Cluster"),
 			Value: aws.String(r.Cluster),
-		},
+		})
 	}
 
 	// Add custom dimension if provided

--- a/backend/newrelic.go
+++ b/backend/newrelic.go
@@ -56,8 +56,11 @@ func (nr *NewRelicBackend) Collect(r *collector.Result) error {
 // toCustomEvent converts a map of metrics to a valid New Relic event body
 func toCustomEvent(clusterName, queueName string, queueMetrics map[string]int) map[string]any {
 	eventData := map[string]any{
-		"Cluster": clusterName,
-		"Queue":   queueName,
+		"Queue": queueName,
+	}
+
+	if clusterName != "" {
+		eventData["Cluster"] = clusterName
 	}
 
 	for k, v := range queueMetrics {


### PR DESCRIPTION
#227 added support for clusters, but as was somewhat anticipated, it
broke compatibility with some existing backends because it added a
new dimension/label/tag or some equivalent for the cluster. In this PR,
we refrain from doing so if the cluster is the empty string.

One thing to note is that the cluster is not specified when the process
starts, it is determined from the cluster token by the backend which includes the name
of the cluster in its response. If the token is for unclustered agents,
that part of the response will be the empty string.