### PR TITLE
Allow env vars to control debug logging for the lambda

### DIFF
--- a/lambda/main.go
+++ b/lambda/main.go
@@ -57,6 +57,12 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 	quiet := quietString == "1" || quietString == "true"
 	timeout := os.Getenv("BUILDKITE_AGENT_METRICS_TIMEOUT")
 
+	debugEnvVar := os.Getenv("BUILDKITE_AGENT_METRICS_DEBUG")
+	debug := debugEnvVar == "1" || debugEnvVar == "true"
+
+	debugHTTPEnvVar := os.Getenv("BUILDKITE_AGENT_METRICS_DEBUG_HTTP")
+	debugHTTP := debugHTTPEnvVar == "1" || debugHTTPEnvVar == "true"
+
 	if quiet {
 		log.SetOutput(io.Discard)
 	}
@@ -108,8 +114,8 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 			Token:     token,
 			Queues:    queues,
 			Quiet:     quiet,
-			Debug:     false,
-			DebugHttp: false,
+			Debug:     debug,
+			DebugHttp: debugHTTP,
 			Timeout:   configuredTimeout,
 		})
 	}


### PR DESCRIPTION
For some reason, these were hard coded to be off. Now, they can be controlled with env vars.
For the non lambda mode, there are already command line arguments for these.