### PR TITLE
Add v5 to module path

### DIFF
--- a/backend/backends.go
+++ b/backend/backends.go
@@ -1,6 +1,6 @@
 package backend
 
-import "github.com/buildkite/buildkite-agent-metrics/collector"
+import "github.com/buildkite/buildkite-agent-metrics/v5/collector"
 
 // Backend is a receiver of metrics
 type Backend interface {

--- a/backend/cloudwatch.go
+++ b/backend/cloudwatch.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
-	"github.com/buildkite/buildkite-agent-metrics/collector"
+	"github.com/buildkite/buildkite-agent-metrics/v5/collector"
 )
 
 // CloudWatchDimension is a dimension to add to metrics

--- a/backend/newrelic.go
+++ b/backend/newrelic.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/buildkite/buildkite-agent-metrics/collector"
+	"github.com/buildkite/buildkite-agent-metrics/v5/collector"
 	newrelic "github.com/newrelic/go-agent"
 )
 

--- a/backend/prometheus.go
+++ b/backend/prometheus.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/buildkite/buildkite-agent-metrics/collector"
+	"github.com/buildkite/buildkite-agent-metrics/v5/collector"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"

--- a/backend/prometheus_test.go
+++ b/backend/prometheus_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/buildkite/buildkite-agent-metrics/collector"
+	"github.com/buildkite/buildkite-agent-metrics/v5/collector"
 	"github.com/google/go-cmp/cmp"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"

--- a/backend/stackdriver.go
+++ b/backend/stackdriver.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/buildkite/buildkite-agent-metrics/collector"
+	"github.com/buildkite/buildkite-agent-metrics/v5/collector"
 	"google.golang.org/genproto/googleapis/api/label"
 	"google.golang.org/protobuf/types/known/timestamppb"
 

--- a/backend/statsd.go
+++ b/backend/statsd.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-go/statsd"
-	"github.com/buildkite/buildkite-agent-metrics/collector"
+	"github.com/buildkite/buildkite-agent-metrics/v5/collector"
 )
 
 // StatsD sends metrics to StatsD (Datadog spec)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/buildkite/buildkite-agent-metrics
+module github.com/buildkite/buildkite-agent-metrics/v5
 
 go 1.20
 

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -17,10 +17,10 @@ import (
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/aws/aws-sdk-go/service/ssm"
 
-	"github.com/buildkite/buildkite-agent-metrics/backend"
-	"github.com/buildkite/buildkite-agent-metrics/collector"
-	"github.com/buildkite/buildkite-agent-metrics/token"
-	"github.com/buildkite/buildkite-agent-metrics/version"
+	"github.com/buildkite/buildkite-agent-metrics/v5/backend"
+	"github.com/buildkite/buildkite-agent-metrics/v5/collector"
+	"github.com/buildkite/buildkite-agent-metrics/v5/token"
+	"github.com/buildkite/buildkite-agent-metrics/v5/version"
 )
 
 const (

--- a/main.go
+++ b/main.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/buildkite/buildkite-agent-metrics/backend"
-	"github.com/buildkite/buildkite-agent-metrics/collector"
-	"github.com/buildkite/buildkite-agent-metrics/version"
+	"github.com/buildkite/buildkite-agent-metrics/v5/backend"
+	"github.com/buildkite/buildkite-agent-metrics/v5/collector"
+	"github.com/buildkite/buildkite-agent-metrics/v5/version"
 )
 
 // Where we send metrics

--- a/token/secretsmanager_test.go
+++ b/token/secretsmanager_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
-	"github.com/buildkite/buildkite-agent-metrics/token/mock"
+	"github.com/buildkite/buildkite-agent-metrics/v5/token/mock"
 	"github.com/golang/mock/gomock"
 )
 

--- a/token/ssm_test.go
+++ b/token/ssm_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
-	"github.com/buildkite/buildkite-agent-metrics/token/mock"
+	"github.com/buildkite/buildkite-agent-metrics/v5/token/mock"
 	"github.com/golang/mock/gomock"
 )
 


### PR DESCRIPTION
> For module versions v2 and later, this value must end with the major version number, such as /v2.
> -- https://go.dev/doc/modules/gomod-ref

This is necessary for #247.