### PR TITLE
Log DNS resolution times when debug http is enabled

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -144,11 +145,29 @@ func (c *Collector) collectAllQueues(httpClient *http.Client, result *Result) er
 
 	if c.DebugHttp {
 		trace := &httptrace.ClientTrace{
-			DNSStart: func(dnsInfo httptrace.DNSStartInfo) {
+			DNSStart: func(_ httptrace.DNSStartInfo) {
 				fmt.Printf("dns start: %v\n", time.Now())
 			},
-			DNSDone: func(dnsDoneInfo httptrace.DNSDoneInfo) {
-				fmt.Printf("dns end: %v\n", time.Now())
+			DNSDone: func(_ httptrace.DNSDoneInfo) {
+				fmt.Printf("dns done: %v\n", time.Now())
+			},
+			ConnectStart: func(_, _ string) {
+				fmt.Printf("connection start: %v\n", time.Now())
+			},
+			ConnectDone: func(_, _ string, _ error) {
+				fmt.Printf("connection done: %v\n", time.Now())
+			},
+			TLSHandshakeStart: func() {
+				fmt.Printf("TLS Handshake start: %v\n", time.Now())
+			},
+			TLSHandshakeDone: func(_ tls.ConnectionState, _ error) {
+				fmt.Printf("TLS Handshake done: %v\n", time.Now())
+			},
+			WroteHeaders: func() {
+				fmt.Printf("wrote headers: %v\n", time.Now())
+			},
+			WroteRequest: func(_ httptrace.WroteRequestInfo) {
+				fmt.Printf("wrote request: %v\n", time.Now())
 			},
 		}
 
@@ -270,11 +289,29 @@ func (c *Collector) collectQueue(httpClient *http.Client, result *Result, queue 
 
 	if c.DebugHttp {
 		trace := &httptrace.ClientTrace{
-			DNSStart: func(dnsInfo httptrace.DNSStartInfo) {
+			DNSStart: func(_ httptrace.DNSStartInfo) {
 				fmt.Printf("dns start: %v\n", time.Now())
 			},
-			DNSDone: func(dnsDoneInfo httptrace.DNSDoneInfo) {
-				fmt.Printf("dns end: %v\n", time.Now())
+			DNSDone: func(_ httptrace.DNSDoneInfo) {
+				fmt.Printf("dns done: %v\n", time.Now())
+			},
+			ConnectStart: func(_, _ string) {
+				fmt.Printf("connection start: %v\n", time.Now())
+			},
+			ConnectDone: func(_, _ string, _ error) {
+				fmt.Printf("connection done: %v\n", time.Now())
+			},
+			TLSHandshakeStart: func() {
+				fmt.Printf("TLS Handshake start: %v\n", time.Now())
+			},
+			TLSHandshakeDone: func(_ tls.ConnectionState, _ error) {
+				fmt.Printf("TLS Handshake done: %v\n", time.Now())
+			},
+			WroteHeaders: func() {
+				fmt.Printf("wrote headers: %v\n", time.Now())
+			},
+			WroteRequest: func(_ httptrace.WroteRequestInfo) {
+				fmt.Printf("wrote request: %v\n", time.Now())
 			},
 		}
 

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/http/httptrace"
 	"net/http/httputil"
 	"net/url"
 	"strconv"
@@ -142,6 +143,16 @@ func (c *Collector) collectAllQueues(httpClient *http.Client, result *Result) er
 	req.Header.Set("Authorization", fmt.Sprintf("Token %s", c.Token))
 
 	if c.DebugHttp {
+		trace := &httptrace.ClientTrace{
+			DNSStart: func(dnsInfo httptrace.DNSStartInfo) {
+				fmt.Printf("dns start: %v\n", time.Now())
+			},
+			DNSDone: func(dnsDoneInfo httptrace.DNSDoneInfo) {
+				fmt.Printf("dns end: %v\n", time.Now())
+			},
+		}
+
+		req = req.WithContext(httptrace.WithClientTrace(req.Context(), trace))
 		if dump, err := httputil.DumpRequest(req, true); err == nil {
 			log.Printf("DEBUG request uri=%s\n%s\n", req.URL, dump)
 		}
@@ -258,6 +269,16 @@ func (c *Collector) collectQueue(httpClient *http.Client, result *Result, queue 
 	req.Header.Set("Authorization", fmt.Sprintf("Token %s", c.Token))
 
 	if c.DebugHttp {
+		trace := &httptrace.ClientTrace{
+			DNSStart: func(dnsInfo httptrace.DNSStartInfo) {
+				fmt.Printf("dns start: %v\n", time.Now())
+			},
+			DNSDone: func(dnsDoneInfo httptrace.DNSDoneInfo) {
+				fmt.Printf("dns end: %v\n", time.Now())
+			},
+		}
+
+		req = req.WithContext(httptrace.WithClientTrace(req.Context(), trace))
 		if dump, err := httputil.DumpRequest(req, true); err == nil {
 			log.Printf("DEBUG request uri=%s\n%s\n", req.URL, dump)
 		}


### PR DESCRIPTION
We print the time when a request starts and a response is received, but this also includes any DNS resolution.
To help debug slow DNS issues this PR now prints the timings when it starts/stops.

Inspired by https://github.com/golang/go/issues/21906#issuecomment-332116942


Output:
```
dns start: 2024-05-03 17:25:37.519031 +1000 AEST m=+0.013530292
dns done: 2024-05-03 17:25:37.556161 +1000 AEST m=+0.050660126
connection start: 2024-05-03 17:25:37.556272 +1000 AEST m=+0.050770667
connection done: 2024-05-03 17:25:37.708357 +1000 AEST m=+0.202855251
TLS Handshake start: 2024-05-03 17:25:37.70846 +1000 AEST m=+0.202958042
TLS Handshake done: 2024-05-03 17:25:37.872324 +1000 AEST m=+0.366821292
wrote headers: 2024-05-03 17:25:37.872614 +1000 AEST m=+0.367111959
wrote request: 2024-05-03 17:25:37.87262 +1000 AEST m=+0.367117334
```