### PR TITLE
This change will ensure a single HTTP client is created

### DIFF
--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -24,6 +24,7 @@ func TestCollectorWithEmptyResponseForAllQueues(t *testing.T) {
 		}
 	}))
 	c := &Collector{
+		Client:    &http.Client{},
 		Endpoint:  s.URL,
 		Token:     "abc123",
 		UserAgent: "some-client/1.2.3",
@@ -86,6 +87,7 @@ func TestCollectorWithNoJobsForAllQueues(t *testing.T) {
 		}
 	}))
 	c := &Collector{
+		Client:    &http.Client{},
 		Endpoint:  s.URL,
 		Token:     "abc123",
 		UserAgent: "some-client/1.2.3",
@@ -165,6 +167,7 @@ func TestCollectorWithSomeJobsAndAgentsForAllQueues(t *testing.T) {
 		}
 	}))
 	c := &Collector{
+		Client:    &http.Client{},
 		Endpoint:  s.URL,
 		Token:     "abc123",
 		UserAgent: "some-client/1.2.3",
@@ -244,6 +247,7 @@ func TestCollectorWithSomeJobsAndAgentsForAQueue(t *testing.T) {
 		}
 	}))
 	c := &Collector{
+		Client:    &http.Client{},
 		Endpoint:  s.URL,
 		Token:     "abc123",
 		UserAgent: "some-client/1.2.3",

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -104,11 +104,14 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 		return "", err
 	}
 
+	httpClient := collector.NewHTTPClient(configuredTimeout)
+
 	userAgent := fmt.Sprintf("buildkite-agent-metrics/%s buildkite-agent-metrics-lambda", version.Version)
 
 	collectors := make([]*collector.Collector, 0, len(tokens))
 	for _, token := range tokens {
 		collectors = append(collectors, &collector.Collector{
+			Client:    httpClient,
 			UserAgent: userAgent,
 			Endpoint:  "https://agent.buildkite.com/v3",
 			Token:     token,
@@ -116,7 +119,6 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 			Quiet:     quiet,
 			Debug:     debug,
 			DebugHttp: debugHTTP,
-			Timeout:   configuredTimeout,
 		})
 	}
 

--- a/main.go
+++ b/main.go
@@ -141,9 +141,12 @@ func main() {
 		}
 	}
 
+	httpClient := collector.NewHTTPClient(*timeout)
+
 	collectors := make([]*collector.Collector, 0, len(tokens))
 	for _, token := range tokens {
 		collectors = append(collectors, &collector.Collector{
+			Client:    httpClient,
 			UserAgent: userAgent,
 			Endpoint:  *endpoint,
 			Token:     token,
@@ -151,7 +154,6 @@ func main() {
 			Quiet:     *quiet,
 			Debug:     *debug,
 			DebugHttp: *debugHttp,
-			Timeout:   *timeout,
 		})
 	}
 


### PR DESCRIPTION
To ensure we get consistent connection reuse, pooling I have extracted the HTTP Client used by all collections. This client has been configured with a set of timeouts at both the client and transport level.

I have used the following post as a reference https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts
