### PR TITLE
fix to remove reset in prometheus backend

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,6 +19,8 @@ import (
 var metricsBackend backend.Backend
 
 func main() {
+	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
+
 	var (
 		interval     = flag.Duration("interval", 0, "Update metrics every interval, rather than once")
 		showVersion  = flag.Bool("version", false, "Show the version")


### PR DESCRIPTION
This has been reoved as it can't work for more than one cluster as gauges are scoped to all clusters, but the collect function is called once for each agent token. In summary this leads to gauges only being correct for the last agent, depending what metrics were returned when the cluster was polled as the result doesn't always include all keys. 😭 

Also trimmed the pipeline metrics as they aren't used, and ensured the logger included short file name as it is helpful.

Added some comments to ensure my assumptions are captured and avoid confusion in the future.
