### PR TITLE
Fix stale Prometheus metrics

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -32,6 +32,17 @@ const (
 	PollDurationHeader = `Buildkite-Agent-Metrics-Poll-Duration`
 )
 
+var AllMetrics = []string{
+	ScheduledJobsCount,
+	RunningJobsCount,
+	UnfinishedJobsCount,
+	WaitingJobsCount,
+	IdleAgentCount,
+	BusyAgentCount,
+	TotalAgentCount,
+	BusyAgentPercentage,
+}
+
 var ErrUnauthorized = errors.New("unauthorized")
 
 var traceLog = log.New(os.Stderr, "TRACE", log.Ldate|log.Ltime|log.Lmicroseconds|log.Lshortfile|log.Lmsgprefix)


### PR DESCRIPTION
### What

Pre-register all metrics with Prometheus, and change which data structure is looped over so that metrics that are no longer present in the collector result (typically for queues that exist but might not have agents or jobs) are naturally reset to 0.

### Why

Fixes #304 