### PR TITLE
Fix regression with HTTP Client and Proxy environment variables

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -414,6 +414,7 @@ func NewHTTPClient(timeout, maxIdleConns int) *http.Client {
 	return &http.Client{
 		Timeout: connectionTimeout,
 		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			MaxIdleConns:          maxIdleConns,
 			IdleConnTimeout:       connectionTimeout,
 			ResponseHeaderTimeout: connectionTimeout,

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 )
 
@@ -281,5 +282,14 @@ func TestCollectorWithSomeJobsAndAgentsForAQueue(t *testing.T) {
 				t.Fatalf("%s was %d; want %d", tc.Key, tc.Counts[tc.Key], tc.Expected)
 			}
 		})
+	}
+}
+
+func TestCollectorWithProxy(t *testing.T) {
+	os.Setenv("HTTP_PROXY", "http://unit.test")
+	client := NewHTTPClient(1, 1)
+	proxyHost := client.Transport.(*http.Transport).Proxy
+	if proxyHost == nil {
+		t.Fatalf("Proxy was not picked up from env.")
 	}
 }


### PR DESCRIPTION
Make sure to add Proxy config in Transport.

See https://pkg.go.dev/net/http#DefaultTransport for reference

Fixes #319