### PR TITLE
Don't hardcode linux/amd64 or GO111MODULE in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM public.ecr.aws/docker/library/golang:1.23.3@sha256:73f06be4578c9987ce560087e2e2ea6485fb605e3910542cadd8fa09fc5f3e31 as builder
+FROM public.ecr.aws/docker/library/golang:1.23.3@sha256:73f06be4578c9987ce560087e2e2ea6485fb605e3910542cadd8fa09fc5f3e31 AS builder
 WORKDIR /go/src/github.com/buildkite/buildkite-agent-metrics/
 COPY . .
-RUN GO111MODULE=on GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o buildkite-agent-metrics .
+RUN CGO_ENABLED=0 go build -o buildkite-agent-metrics .
 
 FROM public.ecr.aws/docker/library/alpine:3.20.3@sha256:1e42bbe2508154c9126d48c2b8a75420c3544343bf86fd041fb7527e017a4b4a
-RUN apk update && apk add curl ca-certificates
+RUN apk update && apk add --no-cache curl ca-certificates
 COPY --from=builder /go/src/github.com/buildkite/buildkite-agent-metrics/buildkite-agent-metrics .
 EXPOSE 8080 8125
 ENTRYPOINT ["./buildkite-agent-metrics"]


### PR DESCRIPTION
`GO111MODULE=on` has been the default for... a while now.

`GOARCH=arm64` gets in the way of building a usable image if you just want the current arch.

`GOOS=linux` is possibly still relevant. 🤔 

Other tweaks:
* `apk add --no-cache`
* Fix Docker complaint about matching case (`FROM` vs `as`)
