### PR TITLE
Pipeline cleanups

### DIFF
--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -1,5 +1,0 @@
-FROM buildkite/agent:3.45.0 AS agent
-
-FROM public.ecr.aws/docker/library/golang:1.20.2-alpine3.17
-COPY --from=agent /usr/local/bin/buildkite-agent /usr/local/bin/buildkite-agent
-RUN apk --no-cache add bash zip curl aws-cli github-cli

--- a/.buildkite/Dockerfile.build
+++ b/.buildkite/Dockerfile.build
@@ -1,0 +1,3 @@
+FROM public.ecr.aws/docker/library/golang:1.23.3-alpine@sha256:c694a4d291a13a9f9d94933395673494fc2cc9d4777b85df3a7e70b3492d3574
+
+RUN apk add --no-cache zip

--- a/.buildkite/Dockerfile.release
+++ b/.buildkite/Dockerfile.release
@@ -1,0 +1,3 @@
+FROM public.ecr.aws/docker/library/golang:1.23.3-alpine@sha256:c694a4d291a13a9f9d94933395673494fc2cc9d4777b85df3a7e70b3492d3574
+
+RUN apk add --no-cache aws-cli bash curl github-cli

--- a/.buildkite/Dockerfile.test
+++ b/.buildkite/Dockerfile.test
@@ -1,0 +1,1 @@
+FROM public.ecr.aws/docker/library/golang:1.23.3@sha256:73f06be4578c9987ce560087e2e2ea6485fb605e3910542cadd8fa09fc5f3e31

--- a/.buildkite/docker-compose.yaml
+++ b/.buildkite/docker-compose.yaml
@@ -1,19 +1,45 @@
-version: "3.9"
-
 services:
-  agent:
+  build:
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile.build
     volumes:
-      - ../:/workspace:cached
-    working_dir: /workspace
+      - ../:/work:cached
+      - ~/gocache:/gocache
+      - ~/gomodcache:/gomodcache
+    working_dir: /work
     environment:
-      - BUILDKITE_BUILD_NUMBER
-      - BUILDKITE_BUILD_ID
-      - BUILDKITE_JOB_ID
-      - BUILDKITE_BRANCH
-      - BUILDKITE_TAG
+      - GOCACHE=/gocache
+      - GOMODCACHE=/gomodcache
+
+  test:
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+    volumes:
+      - ../:/work:cached
+      - ~/gocache:/gocache
+      - ~/gomodcache:/gomodcache
+    working_dir: /work
+    environment:
+      - GOCACHE=/gocache
+      - GOMODCACHE=/gomodcache
+
+  release:
+    build:
+      context: .
+      dockerfile: Dockerfile.release
+    volumes:
+      - ../:/work:cached
+    working_dir: /work
+    environment:
       - BUILDKITE_AGENT_ACCESS_TOKEN
+      - BUILDKITE_AGENT_TAGS=queue=default
+      - BUILDKITE_BRANCH
+      - BUILDKITE_BUILD_ID
+      - BUILDKITE_BUILD_NUMBER
+      - BUILDKITE_BUILD_PATH=/buildkite
+      - BUILDKITE_JOB_ID
+      - BUILDKITE_TAG
       - GITHUB_RELEASE_ACCESS_TOKEN
       - RELEASE_DRY_RUN

--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -9,7 +9,7 @@ steps:
     agents:
       queue: "elastic-runners"
     concurrency: 1
-    concurrency_group: 'release_buildkite_metrics_github'
+    concurrency_group: "release_buildkite_metrics_github"
     plugins:
       - aws-assume-role-with-web-identity:
           role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-buildkite-agent-metrics
@@ -26,6 +26,8 @@ steps:
       - aws-ssm#v1.0.0:
           parameters:
             GITHUB_RELEASE_ACCESS_TOKEN: /pipelines/buildkite/buildkite-agent-metrics/GITHUB_RELEASE_ACCESS_TOKEN
-      - docker-compose#v4.14.0:
+      - docker-compose#v5.5.0:
           config: .buildkite/docker-compose.yaml
-          run: agent
+          run: build
+          cli-version: 2
+          mount-buildkite-agent: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,35 +3,47 @@ steps:
     key: test
     command: go test -v -race ./...
     plugins:
-      - docker#v5.9.0:
-          image: golang:1.21
+      - docker-compose#v5.5.0:
+          config: .buildkite/docker-compose.yaml
+          cli-version: 2
+          run: test
 
   - group: ":hammer_and_wrench: Binary builds"
     steps:
-    - name: ":{{matrix.os}}: Build {{matrix.os}} {{matrix.arch}} binary"
-      command: .buildkite/steps/build-binary.sh {{matrix.os}} {{matrix.arch}}
-      key: build-binary
-      depends_on:
-        - test
-      plugins:
-        - docker#v5.9.0:
-            image: golang:1.21
-            mount-buildkite-agent: true
-      matrix:
-        setup:
-          os:
-            - darwin
-            - linux
-            - windows
-          arch:
-            - amd64
-            - arm64
+      - name: ":{{matrix.os}}: Build {{matrix.os}} {{matrix.arch}} binary"
+        command: .buildkite/steps/build-binary.sh {{matrix.os}} {{matrix.arch}}
+        key: build-binary
+        depends_on:
+          - test
+        plugins:
+          - docker-compose#v5.5.0:
+              config: .buildkite/docker-compose.yaml
+              cli-version: 2
+              run: build
+        matrix:
+          setup:
+            os:
+              - darwin
+              - linux
+              - windows
+            arch:
+              - amd64
+              - arm64
+        artifact_paths:
+          - ./dist/*
 
   - name: ":lambda: Build Lambda"
     key: build-lambda
     depends_on:
       - test
     command: .buildkite/steps/build-lambda.sh
+    plugins:
+      - docker-compose#v5.5.0:
+          config: .buildkite/docker-compose.yaml
+          cli-version: 2
+          run: build
+    artifact_paths:
+      - ./dist/*
 
   - name: ":s3: Upload to S3"
     key: upload-to-s3

--- a/.buildkite/steps/build-binary.sh
+++ b/.buildkite/steps/build-binary.sh
@@ -9,5 +9,5 @@ export GOOS
 export GOARCH
 export CGO_ENABLED=0
 
-go build -o "buildkite-agent-metrics-${GOOS}-${GOARCH}" .
-buildkite-agent artifact upload "buildkite-agent-metrics-${GOOS}-${GOARCH}"
+mkdir -p dist
+go build -o "dist/buildkite-agent-metrics-${GOOS}-${GOARCH}" .

--- a/.buildkite/steps/build-lambda.sh
+++ b/.buildkite/steps/build-lambda.sh
@@ -1,17 +1,9 @@
 #!/usr/bin/env sh
-
 set -eu
 
-docker run --rm --volume "$PWD:/code" \
-  --workdir /code \
-  --rm \
-  --env CGO_ENABLED=0 \
-  golang:1.21 \
-    go build -tags lambda.norpc -o lambda/bootstrap ./lambda
+CGO_ENABLED=0 go build -tags lambda.norpc -o lambda/bootstrap ./lambda
 
 chmod +x lambda/bootstrap
 
-mkdir -p dist/
-zip -j handler.zip lambda/bootstrap
-
-buildkite-agent artifact upload handler.zip
+mkdir -p dist
+zip -j dist/handler.zip lambda/bootstrap

--- a/.buildkite/steps/release-github.sh
+++ b/.buildkite/steps/release-github.sh
@@ -15,8 +15,7 @@ git fetch --prune --force origin "+refs/tags/*:refs/tags/*"
 echo --- Downloading binaries
 rm -rf dist
 mkdir -p dist
-buildkite-agent artifact download handler.zip ./dist
-buildkite-agent artifact download "buildkite-agent-metrics-*" ./dist
+buildkite-agent artifact download "dist/*" ./dist
 
 echo --- Checking tags
 version=$(awk -F\" '/const Version/ {print $2}' version/version.go)

--- a/.buildkite/steps/upload-to-s3.sh
+++ b/.buildkite/steps/upload-to-s3.sh
@@ -37,10 +37,11 @@ else
 fi
 
 echo "~~~ :buildkite: Downloading artifacts"
-buildkite-agent artifact download handler.zip .
+mkdir -p dist
+buildkite-agent artifact download dist/handler.zip ./dist
 
 echo "--- :s3: Uploading lambda to ${BASE_BUCKET}/${BUCKET_PATH}/ in ${AWS_DEFAULT_REGION}"
-aws s3 cp --acl public-read handler.zip "s3://${BASE_BUCKET}/${BUCKET_PATH}/handler.zip"
+aws s3 cp --acl public-read dist/handler.zip "s3://${BASE_BUCKET}/${BUCKET_PATH}/handler.zip"
 
 for region in "${EXTRA_REGIONS[@]}" ; do
 	bucket="${BASE_BUCKET}-${region}"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,9 @@ updates:
     reviewers:
       - "buildkite/pipelines-dispatch"
   - package-ecosystem: "docker"
-    directory: "/"
+    directories:
+      - "/"
+      - ".buildkite"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 2


### PR DESCRIPTION
* Use the `docker-compose` plugin
* Dockerfiles, so all steps use dependabot-updated images pulled from the cache
* `artifact_paths` instead of copying the agent into the container