### PR TITLE
Fix --tag flags generated from Bash array

### DIFF
--- a/.buildkite/steps/release-docker.sh
+++ b/.buildkite/steps/release-docker.sh
@@ -80,7 +80,7 @@ release_dry_run docker buildx build \
     --progress plain \
     --builder "${builder_name}" \
     --tag "${registry}:latest" \
-    "${version_tags[@]/#/--tag ${registry}:v}" \
+    "${version_tags[@]/#/--tag=${registry}:v}" \
     --platform linux/amd64,linux/arm64 \
     --file .buildkite/Dockerfile.public \
     --push \


### PR DESCRIPTION
`--tag foo:bar` as a single arg is not a valid flag, but `--tag=foo:bar` is valid.

Small bit of manual testing this time:

```shell
bash-3.2$ parse_version() {
>   local v="$1"
>   IFS='.' read -r -a parts <<< "${v%-*}"
>
>   for idx in $(seq 1 ${#parts[*]}) ; do
>     sed -e 's/ /./g' <<< "${parts[@]:0:$idx}"
>   done
>
>   [[ "${v%-*}" == "${v}" ]] || echo "${v}"
> }
bash-3.2$ registry="public.ecr.aws/buildkite/agent-metrics"
bash-3.2$ version_tags=($(parse_version "5.9.11"))
bash-3.2$ docker build "${version_tags[@]/#/--tag=${registry}:v}" .
[+] Building 17.2s (13/13) FINISHED                                          docker:orbstack

...snip...

 => => writing image sha256:b5162648ecf2f901b463c852eab2acfc2dfb0acd0aad5e7b2e77bb28c0  0.0s
 => => naming to public.ecr.aws/buildkite/agent-metrics:v5                              0.0s
 => => naming to public.ecr.aws/buildkite/agent-metrics:v5.9                            0.0s
 => => naming to public.ecr.aws/buildkite/agent-metrics:v5.9.11                         0.0s
```