### PR TITLE
Simplify docker release script

### DIFF
--- a/.buildkite/steps/release-docker.sh
+++ b/.buildkite/steps/release-docker.sh
@@ -30,32 +30,7 @@ rm -rf dist
 mkdir -p dist
 buildkite-agent artifact download --build "${BUILDKITE_TRIGGERED_FROM_BUILD_ID}" "dist/buildkite-agent-metrics-linux-*" ./dist
 
-echo "--- Building :docker: image"
-
-builder_name="$(docker buildx create --use)"
-# shellcheck disable=SC2064 # we want the current $builder_name to be trapped, not the runtime one
-trap "docker buildx rm ${builder_name} || true" EXIT
-
-echo "--- Building :docker: ${image_tag} for all architectures"
-docker buildx build \
-  --progress plain \
-  --builder "${builder_name}" \
-  --platform linux/amd64,linux/arm64 \
-  --file .buildkite/Dockerfile.public \
-  .
-
-# Tag images for just the native architecture. There is a limitation in docker that prevents this
-# from being done in one command. Luckliy the second build will be quick because of docker layer caching
-# As this is just a native build, we don't need the lock.
-docker buildx build \
-  --progress plain \
-  --builder "${builder_name}" \
-  --tag "${image_tag}" \
-  --file .buildkite/Dockerfile.public \
-  --load \
-  .
-
-echo --- :ecr: Pushing to ECR
+echo --- :ecr: Building and Pushing to ECR
 
 # Convert 2.3.2 into [ 2.3.2 2.3 2 ] or 3.0-beta.42 in [ 3.0-beta.42 3.0 3 ]
 parse_version() {
@@ -71,14 +46,11 @@ parse_version() {
 
 version_tags=($(parse_version "${version#v}"))
 
-# Do another build with all architectures and tags. The layers should be cached
-# from the previous build with all architectures.
 # Pushing to the docker registry in this way greatly simplifies creating the
 # manifest list on the docker registry so that either architecture can be pulled
 # with the same tag.
 release_dry_run docker buildx build \
     --progress plain \
-    --builder "${builder_name}" \
     --tag "${registry}:latest" \
     "${version_tags[@]/#/--tag=${registry}:v}" \
     --platform linux/amd64,linux/arm64 \


### PR DESCRIPTION
It's not super clear to me why we can't do the multi-platform image build *and* push to ECR all in a single command. It might be naive optimism, but it's worth a shot. I don't expect this to speed things up too much, but a simpler script will be easier to maintain over time.

I also removed the creation of a custom buildx builder. These jobs are running on elastic-runners, which already have a buildx builder that's capable of multi-platform builds.