### PR TITLE
Update release process to assume new IAM roles via OIDC

### DIFF
--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -7,7 +7,7 @@ steps:
     concurrency_group: "release_buildkite_metrics_github"
     plugins:
       - aws-assume-role-with-web-identity:
-          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-buildkite-agent-metrics
+          role-arn: arn:aws:iam::172840064832:role/pipeline-buildkite-buildkite-agent-metrics
 
   - label: ":github: Release"
     command: ".buildkite/steps/release-github.sh"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -61,7 +61,7 @@ steps:
     concurrency_group: "release_buildkite_metrics_s3"
     plugins:
       - aws-assume-role-with-web-identity:
-          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-buildkite-agent-metrics
+          role-arn: arn:aws:iam::172840064832:role/pipeline-buildkite-buildkite-agent-metrics
 
   - if: build.env("RELEASE_DRY_RUN") == "true" || build.env("BUILDKITE_TAG") =~ /^v\d+\.\d+\.\d+$$/
     block: ":rocket: Release ${BUILDKITE_TAG:-UNTAGGED}?"

--- a/.buildkite/steps/upload-to-s3.sh
+++ b/.buildkite/steps/upload-to-s3.sh
@@ -3,29 +3,6 @@ set -eu
 
 export AWS_DEFAULT_REGION="us-east-1"
 
-# Updated from https://docs.aws.amazon.com/general/latest/gr/rande.html#lambda_region
-EXTRA_REGIONS=(
-  us-east-2
-  us-west-1
-  us-west-2
-  af-south-1
-  ap-east-1
-  ap-south-1
-  ap-northeast-2
-  ap-northeast-1
-  ap-southeast-2
-  ap-southeast-1
-  ca-central-1
-  eu-central-1
-  eu-west-1
-  eu-west-2
-  eu-south-1
-  eu-west-3
-  eu-north-1
-  me-south-1
-  sa-east-1
-)
-
 VERSION="$(awk -F\" '/const Version/ {print $2}' version/version.go)"
 BASE_BUCKET="buildkite-lambdas"
 BUCKET_PATH="buildkite-agent-metrics"
@@ -46,10 +23,4 @@ else
 fi
 
 echo "--- :s3: Uploading lambda to ${BASE_BUCKET}/${BUCKET_PATH}/ in ${AWS_DEFAULT_REGION}"
-aws s3 cp --acl public-read dist/handler.zip "s3://${BASE_BUCKET}/${BUCKET_PATH}/handler.zip"
-
-for region in "${EXTRA_REGIONS[@]}" ; do
-	bucket="${BASE_BUCKET}-${region}"
-	echo "--- :s3: Copying files to ${bucket}"
-	aws --region "${region}" s3 cp --acl public-read "s3://${BASE_BUCKET}/${BUCKET_PATH}/handler.zip" "s3://${bucket}/${BUCKET_PATH}/handler.zip"
-done
+aws s3 cp dist/handler.zip "s3://${BASE_BUCKET}/${BUCKET_PATH}/handler.zip"


### PR DESCRIPTION
We recently moved the S3 buckets that host our public lambdas to a new AWS account, and the OIDC assumable IAM roles for publishing to the buckets moved with them.

The replacement buckets have the same name, so we don't need to change them. However the recreated buckets use BucketOwnerEnforced for ownership and resource policies for access, instead of ACLs. We need to remove `--acl` from the upload command.

We also took the opportunity to setup S3 bucket replication, so we only need to push to the us-east-1 bucket now. S3 replication will handle copying to all the regional buckets.