### PR TITLE
Group container image bumps into single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,7 @@ updates:
     open-pull-requests-limit: 2
     reviewers:
       - "buildkite/pipelines-dispatch"
+    groups:
+      container-images:
+        patterns:
+          - "*"


### PR DESCRIPTION
Reduce distinct PRs for bumping container images. They all tend to bump simultaneously.