### PR TITLE
Add an environment variable to override the agent endpoint URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ It requires a `provided.al2` environment and respects the following env vars:
    under.
  - `BUILDKITE_CLOUDWATCH_HIGH_RESOLUTION` : Whether to enable [High-Resolution Metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/publishingMetrics.html#high-resolution-metrics) which incurs additional charges. This accepts either `1` or `true` to enable.
 
+To override the endpoint use the following env var:
+
+- `BUILDKITE_AGENT_ENDPOINT`: Endpoint URL of the Buildkite Agent API (default https://agent.buildkite.com/v3)
+
 To adjust timeouts, and connection pooling in the HTTP client use the following env vars:
 
 - `BUILDKITE_AGENT_METRICS_TIMEOUT` : Timeout, in seconds, TLS handshake and idle connections, for HTTP requests, to Buildkite API (default 15).

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -24,6 +24,7 @@ import (
 )
 
 const (
+	BKAgentEndpointEnvVar                    = "BUILDKITE_AGENT_ENDPOINT"
 	BKAgentTokenEnvVar                       = "BUILDKITE_AGENT_TOKEN"
 	BKAgentTokenSSMKeyEnvVar                 = "BUILDKITE_AGENT_TOKEN_SSM_KEY"
 	BKAgentTokenSecretsManagerSecretIDEnvVar = "BUILDKITE_AGENT_SECRETS_MANAGER_SECRET_ID"
@@ -112,12 +113,18 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 
 	userAgent := fmt.Sprintf("buildkite-agent-metrics/%s buildkite-agent-metrics-lambda", version.Version)
 
+	endpoint := "https://agent.buildkite.com/v3"
+
+	if bkAgentEndpoint := os.Getenv(BKAgentEndpointEnvVar); bkAgentEndpoint != "" {
+		endpoint = bkAgentEndpoint
+	}
+
 	collectors := make([]*collector.Collector, 0, len(tokens))
 	for _, token := range tokens {
 		collectors = append(collectors, &collector.Collector{
 			Client:    httpClient,
 			UserAgent: userAgent,
-			Endpoint:  "https://agent.buildkite.com/v3",
+			Endpoint:  endpoint,
 			Token:     token,
 			Queues:    queues,
 			Quiet:     quiet,

--- a/main.go
+++ b/main.go
@@ -33,17 +33,17 @@ func main() {
 		maxIdleConns = flag.Int("max-idle-conns", 100, "Maximum number of idle (keep-alive) HTTP connections for Buildkite Agent API. Zero means no limit, -1 disables connection reuse.")
 
 		// backend config
-		backendOpt     = flag.String("backend", "cloudwatch", "Specify the backend to use: cloudwatch, newrelic, prometheus, stackdriver, statsd")
-		statsdHost     = flag.String("statsd-host", "127.0.0.1:8125", "Specify the StatsD server")
-		statsdTags     = flag.Bool("statsd-tags", false, "Whether your StatsD server supports tagging like Datadog")
-		prometheusAddr = flag.String("prometheus-addr", ":8080", "Prometheus metrics transport bind address")
-		prometheusPath = flag.String("prometheus-path", "/metrics", "Prometheus metrics transport path")
-		clwRegion      = flag.String("cloudwatch-region", "", "AWS Region to connect to, defaults to $AWS_REGION or us-east-1")
-		clwDimensions  = flag.String("cloudwatch-dimensions", "", "Cloudwatch dimensions to index metrics under, in the form of Key=Value, Other=Value")
+		backendOpt        = flag.String("backend", "cloudwatch", "Specify the backend to use: cloudwatch, newrelic, prometheus, stackdriver, statsd")
+		statsdHost        = flag.String("statsd-host", "127.0.0.1:8125", "Specify the StatsD server")
+		statsdTags        = flag.Bool("statsd-tags", false, "Whether your StatsD server supports tagging like Datadog")
+		prometheusAddr    = flag.String("prometheus-addr", ":8080", "Prometheus metrics transport bind address")
+		prometheusPath    = flag.String("prometheus-path", "/metrics", "Prometheus metrics transport path")
+		clwRegion         = flag.String("cloudwatch-region", "", "AWS Region to connect to, defaults to $AWS_REGION or us-east-1")
+		clwDimensions     = flag.String("cloudwatch-dimensions", "", "Cloudwatch dimensions to index metrics under, in the form of Key=Value, Other=Value")
 		clwHighResolution = flag.Bool("cloudwatch-high-resolution", false, "Send metrics at a high-resolution, which incurs extra costs")
-		gcpProjectID   = flag.String("stackdriver-projectid", "", "Specify Stackdriver Project ID")
-		nrAppName      = flag.String("newrelic-app-name", "", "New Relic application name for metric events")
-		nrLicenseKey   = flag.String("newrelic-license-key", "", "New Relic license key for publishing events")
+		gcpProjectID      = flag.String("stackdriver-projectid", "", "Specify Stackdriver Project ID")
+		nrAppName         = flag.String("newrelic-app-name", "", "New Relic application name for metric events")
+		nrLicenseKey      = flag.String("newrelic-license-key", "", "New Relic license key for publishing events")
 	)
 
 	// custom config for multiple tokens and queues
@@ -56,6 +56,10 @@ func main() {
 	if *showVersion {
 		fmt.Printf("buildkite-agent-metrics %s\n", version.Version)
 		os.Exit(0)
+	}
+
+	if os.Getenv("BUILDKITE_AGENT_ENDPOINT") != "" {
+		*endpoint = os.Getenv("BUILDKITE_AGENT_ENDPOINT")
 	}
 
 	if len(tokens) == 0 {


### PR DESCRIPTION
This change will enable customers to override the endpoint flag via an **optional** environment variable.