### PR TITLE
Create CODEOWNERS - adding Support Engineers as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @buildkite/support-engineering


### PR DESCRIPTION
Adding CODEOWNERS file with Support Engineers as codeowners.