### PR TITLE
Simplify OpenTelemetry backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ To override the endpoint use the following env var:
 To adjust timeouts, and connection pooling in the HTTP client use the following env vars:
 
 - `BUILDKITE_AGENT_METRICS_TIMEOUT` : Timeout, in seconds, TLS handshake and idle connections, for HTTP requests, to Buildkite API (default 15).
-- `BUILDKITE_AGENT_METRICS_MAX_IDLE_CONNS` : Maximum number of idle (keep-alive) HTTP connections 
+- `BUILDKITE_AGENT_METRICS_MAX_IDLE_CONNS` : Maximum number of idle (keep-alive) HTTP connections
    for Buildkite Agent API. Zero means no limit, -1 disables pooling (default 100).
 
 To assist with debugging the following env vars are provided:
@@ -411,12 +411,12 @@ We send metrics for Jobs in the following states:
 - **Waiting**: the job is known to exist but isn't schedulable yet due to
   dependencies, `wait` statements, etc. This information is mostly useful to an
   autoscaler, since it represents work that will start soon.
-- **Running**: the jobs that are currently in the "running" state. These jobs have been 
+- **Running**: the jobs that are currently in the "running" state. These jobs have been
   picked up by agents and are actively being executed.
 - **Unfinished**: the jobs that have been scheduled but have not yet
   finished. This count includes jobs that are in the states "running" and "scheduled".
 
-Detailed explanations about some of the metrics: 
+Detailed explanations about some of the metrics:
 
 **RunningJobsCount**: This metric counts the number of jobs that are currently in the "running" state. These jobs have been picked up by agents and are actively being executed.
 
@@ -424,7 +424,7 @@ Detailed explanations about some of the metrics:
 
 **ScheduledJobsCount**: This metric counts jobs that have been scheduled but are not yet started by any agent. These jobs are in the queue, waiting for an available agent to start executing them.
 
-**WaitingJobsCount**: This metric counts jobs that are in a "waiting" state, which could mean they are waiting on dependencies to resolve, on other jobs to finish, or on any other condition that needs to be met before they can be scheduled. 
+**WaitingJobsCount**: This metric counts jobs that are in a "waiting" state, which could mean they are waiting on dependencies to resolve, on other jobs to finish, or on any other condition that needs to be met before they can be scheduled.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -179,10 +179,6 @@ Usage of buildkite-agent-metrics:
         New Relic application name for metric events
   -newrelic-license-key string
         New Relic license key for publishing events
-  -otel-api-key string
-        OpenTelemetry API key for authentication
-  -otel-endpoint string
-        OpenTelemetry OTLP endpoint (required when using opentelemetry backend)
   -prometheus-addr string
         Prometheus metrics transport bind address (default ":8080")
   -prometheus-path string
@@ -249,53 +245,32 @@ The New Relic backend supports the following arguments:
 
 ### OpenTelemetry
 
-The OpenTelemetry backend allows you to send metrics, traces, and logs to any OpenTelemetry-compatible system.
+The OpenTelemetry backend allows you to send metrics and traces to any OpenTelemetry-compatible using OTLP.
 
 #### Configuration
 
 **Command Line Flags:**
 - `--backend opentelemetry`: Select OpenTelemetry as the metrics backend
-- `--otel-endpoint`: OpenTelemetry OTLP endpoint (required)
-- `--otel-api-key`: OpenTelemetry API key for authentication (optional)
-- `--otel-protocol`: Protocol to use: `http` or `grpc` (default: `http`)
 
 **Environment Variables:**
-- `OTEL_ENDPOINT`: OTLP endpoint (required when using opentelemetry backend)
-- `OTEL_API_KEY`: API key for authentication (optional)
-- `OTEL_PROTOCOL`: Protocol to use: `http` or `grpc` (default: `http`)
+- `OTEL_SERVICE_NAME`: OpenTelemetry service name (default: `buildkite-agent-metrics`)
+- `OTEL_EXPORTER_OTLP_PROTOCOL`: Protocol to use: `http/protobuf` or `grpc` (default: `http/protobuf`)
+- `OTEL_EXPORTER_OTLP_ENDPOINT`: Endpoint to send metrics to (default: `http://localhost:4318` for `http/protobuf` and `http://localhost:4317` for `grpc`)
+- `OTEL_EXPORTER_OTLP_HEADERS`: Headers to send with each request (default: none)
 
-**Service Configuration:**
-- `OTEL_SERVICE_NAME`: Service name (defaults to "buildkite-agent-metrics")
-- `OTEL_SERVICE_NAMESPACE`: Service namespace (defaults to "buildkite-agent-metrics")
-- `OTEL_SERVICE_VERSION`: Service version (uses the binary version)
+See OpenTelemetry SDK documentation for more complete list of supported environment variables.
 
-#### Usage Examples
+- https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
+- https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp
 
-**Basic Usage:**
+#### Usage Example
+
 ```bash
-buildkite-agent-metrics \
-  --backend opentelemetry \
-  --token $YOUR_BUILDKITE_TOKEN \
-  --otel-endpoint https://your-otlp-endpoint.com \
-  --otel-api-key $YOUR_API_KEY \
-  --interval 30s
-```
+export OTEL_SERVICE_NAME="buildkite-metrics"
+export OTEL_EXPORTER_OTLP_ENDPOINT="https://your-otlp-endpoint.com:4317"
+export OTEL_EXPORTER_OTLP_HEADERS="authorization=your-api-key"
+export OTEL_EXPORTER_OTLP_PROTOCOL="grpc"
 
-**Using gRPC protocol:**
-```bash
-buildkite-agent-metrics \
-  --backend opentelemetry \
-  --token $YOUR_BUILDKITE_TOKEN \
-  --otel-endpoint your-otlp-server.com:4317 \
-  --otel-protocol grpc \
-  --interval 30s
-```
-
-**Using environment variables:**
-```bash
-export OTEL_ENDPOINT="https://your-otlp-endpoint.com"
-export OTEL_API_KEY="your-api-key"
-export OTEL_PROTOCOL="http"
 buildkite-agent-metrics \
   --backend opentelemetry \
   --token $YOUR_BUILDKITE_TOKEN \
@@ -308,7 +283,7 @@ buildkite-agent-metrics \
 The following metrics are exported to OpenTelemetry:
 
 - `buildkite.jobs.scheduled`: Number of scheduled jobs
-- `buildkite.jobs.running`: Number of running jobs  
+- `buildkite.jobs.running`: Number of running jobs
 - `buildkite.jobs.unfinished`: Number of unfinished jobs
 - `buildkite.jobs.waiting`: Number of waiting jobs
 - `buildkite.agents.idle`: Number of idle agents
@@ -324,6 +299,7 @@ All metrics include attributes for:
 
 **Traces:**
 Distributed tracing is provided for:
+
 - Metrics collection operations
 - HTTP requests to the Buildkite API
 - Backend metric publishing

--- a/backend/opentelemetry.go
+++ b/backend/opentelemetry.go
@@ -49,6 +49,7 @@ type OpenTelemetryBackend struct {
 // https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
 // https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp
 func NewOpenTelemetryBackend() (*OpenTelemetryBackend, error) {
+	ctx := context.TODO()
 	serviceName := os.Getenv("OTEL_SERVICE_NAME")
 	if serviceName == "" {
 		serviceName = "buildkite-agent-metrics"
@@ -72,9 +73,9 @@ func NewOpenTelemetryBackend() (*OpenTelemetryBackend, error) {
 
 	switch protocol {
 	case "grpc":
-		traceExporter, err = otlptracegrpc.New(context.Background())
+		traceExporter, err = otlptracegrpc.New(ctx)
 	case "http/protobuf", "http":
-		traceExporter, err = otlptracehttp.New(context.Background())
+		traceExporter, err = otlptracehttp.New(ctx)
 	default:
 		return nil, fmt.Errorf("unsupported otlp protocol: %s", protocol)
 	}
@@ -94,12 +95,12 @@ func NewOpenTelemetryBackend() (*OpenTelemetryBackend, error) {
 
 	switch protocol {
 	case "grpc":
-		metricExporter, err = otlpmetricgrpc.New(context.Background())
+		metricExporter, err = otlpmetricgrpc.New(ctx)
 	case "http/protobuf", "http":
-		metricExporter, err = otlpmetrichttp.New(context.Background())
+		metricExporter, err = otlpmetrichttp.New(ctx)
 	}
 	if err != nil {
-		tracerProvider.Shutdown(context.Background())
+		tracerProvider.Shutdown(ctx)
 		return nil, fmt.Errorf("failed to create metric exporter: %w", err)
 	}
 
@@ -118,7 +119,7 @@ func NewOpenTelemetryBackend() (*OpenTelemetryBackend, error) {
 
 	// Create shutdown function
 	otelShutdown := func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
 		defer cancel()
 		tracerProvider.Shutdown(ctx)
 		meterProvider.Shutdown(ctx)
@@ -221,7 +222,7 @@ func (b *OpenTelemetryBackend) initializeMetrics() error {
 
 // Collect implements the Backend interface
 func (b *OpenTelemetryBackend) Collect(r *collector.Result) error {
-	ctx := context.Background()
+	ctx := context.TODO()
 	start := time.Now()
 
 	// Start tracing span for this collection

--- a/backend/opentelemetry.go
+++ b/backend/opentelemetry.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"strings"
+	"os"
 	"time"
 
 	"github.com/buildkite/buildkite-agent-metrics/v5/collector"
+	"github.com/buildkite/buildkite-agent-metrics/v5/version"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
@@ -16,11 +17,11 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/propagation"
-	"go.opentelemetry.io/otel/sdk/resource"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	"go.opentelemetry.io/otel/trace"
 )
 
 type OpenTelemetryBackend struct {
@@ -41,98 +42,42 @@ type OpenTelemetryBackend struct {
 	shutdown func()
 }
 
-type OpenTelemetryConfig struct {
-	ServiceName      string
-	ServiceVersion   string
-	ServiceNamespace string
-	Endpoint         string
-	APIKey           string
-	Protocol         string // "http" or "grpc"
-}
-
-func NewOpenTelemetryBackend(cfg OpenTelemetryConfig) (*OpenTelemetryBackend, error) {
-	// Endpoint is required
-	if cfg.Endpoint == "" {
-		return nil, fmt.Errorf("OTEL endpoint is required")
-	}
-	
-	
-	// Infer protocol from endpoint if not specified
-	if cfg.Protocol == "" {
-		if strings.Contains(cfg.Endpoint, ":4317") {
-			cfg.Protocol = "grpc"
-		} else {
-			cfg.Protocol = "http"
-		}
-	}
-	
-	// Validate protocol
-	if cfg.Protocol != "http" && cfg.Protocol != "grpc" {
-		return nil, fmt.Errorf("OTEL protocol must be 'http' or 'grpc', got: %s", cfg.Protocol)
-	}
-
-	// Set up resource with service information
-	serviceName := "buildkite-agent-metrics"
-	if cfg.ServiceName != "" {
-		serviceName = cfg.ServiceName
-	}
-
-	serviceNamespace := "buildkite-agent-metrics"
-	if cfg.ServiceNamespace != "" {
-		serviceNamespace = cfg.ServiceNamespace
-	}
-
-	resourceAttrs := []attribute.KeyValue{
-		semconv.ServiceName(serviceName),
-		semconv.ServiceNamespace(serviceNamespace),
-	}
-	if cfg.ServiceVersion != "" {
-		resourceAttrs = append(resourceAttrs, semconv.ServiceVersion(cfg.ServiceVersion))
+// NewOpenTelemetryBackend creates a new OpenTelemetry backend.
+//
+// # Configuration is through standard OpenTelemetry SDK environment variables
+//
+// https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
+// https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp
+func NewOpenTelemetryBackend() (*OpenTelemetryBackend, error) {
+	serviceName := os.Getenv("OTEL_SERVICE_NAME")
+	if serviceName == "" {
+		serviceName = "buildkite-agent-metrics"
 	}
 
 	res := resource.NewWithAttributes(
 		semconv.SchemaURL,
-		resourceAttrs...,
+		semconv.ServiceName(serviceName),
+		semconv.ServiceNamespace("buildkite"),
+		semconv.ServiceVersion(version.Version),
 	)
 
 	// Set up trace exporter based on protocol
 	var traceExporter sdktrace.SpanExporter
 	var err error
-	
-	// For HTTP exporters, extract hostname from full URL if needed
-	httpEndpoint := cfg.Endpoint
-	if strings.HasPrefix(cfg.Endpoint, "https://") {
-		httpEndpoint = strings.TrimPrefix(cfg.Endpoint, "https://")
-	} else if strings.HasPrefix(cfg.Endpoint, "http://") {
-		httpEndpoint = strings.TrimPrefix(cfg.Endpoint, "http://")
+	protocol := os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL")
+	// default to http/protobuf as per spec
+	if protocol == "" {
+		protocol = "http/protobuf"
 	}
-	
-	if cfg.Protocol == "grpc" {
-		traceExporterOpts := []otlptracegrpc.Option{
-			otlptracegrpc.WithEndpoint(cfg.Endpoint),
-		}
-		if cfg.APIKey != "" {
-			traceExporterOpts = append(traceExporterOpts, otlptracegrpc.WithHeaders(map[string]string{
-				"authorization": cfg.APIKey,
-			}))
-		}
-		traceExporter, err = otlptracegrpc.New(context.Background(), traceExporterOpts...)
-	} else {
-		traceExporterOpts := []otlptracehttp.Option{
-			otlptracehttp.WithEndpoint(httpEndpoint),
-		}
-		// Only add URL path if endpoint doesn't already contain it
-		if !strings.Contains(httpEndpoint, "/v1/traces") {
-			traceExporterOpts = append(traceExporterOpts, otlptracehttp.WithURLPath("/v1/traces"))
-		}
-		if cfg.APIKey != "" {
-			traceExporterOpts = append(traceExporterOpts, otlptracehttp.WithHeaders(map[string]string{
-				"authorization": cfg.APIKey,
-			}))
-		}
-		traceExporter, err = otlptracehttp.New(context.Background(), traceExporterOpts...)
+
+	switch protocol {
+	case "grpc":
+		traceExporter, err = otlptracegrpc.New(context.Background())
+	case "http/protobuf", "http":
+		traceExporter, err = otlptracehttp.New(context.Background())
+	default:
+		return nil, fmt.Errorf("unsupported otlp protocol: %s", protocol)
 	}
-	
 	if err != nil {
 		return nil, fmt.Errorf("failed to create trace exporter: %w", err)
 	}
@@ -146,33 +91,13 @@ func NewOpenTelemetryBackend(cfg OpenTelemetryConfig) (*OpenTelemetryBackend, er
 
 	// Set up metric exporter based on protocol
 	var metricExporter sdkmetric.Exporter
-	
-	if cfg.Protocol == "grpc" {
-		metricExporterOpts := []otlpmetricgrpc.Option{
-			otlpmetricgrpc.WithEndpoint(cfg.Endpoint),
-		}
-		if cfg.APIKey != "" {
-			metricExporterOpts = append(metricExporterOpts, otlpmetricgrpc.WithHeaders(map[string]string{
-				"authorization": cfg.APIKey,
-			}))
-		}
-		metricExporter, err = otlpmetricgrpc.New(context.Background(), metricExporterOpts...)
-	} else {
-		metricExporterOpts := []otlpmetrichttp.Option{
-			otlpmetrichttp.WithEndpoint(httpEndpoint),
-		}
-		// Only add URL path if endpoint doesn't already contain it
-		if !strings.Contains(httpEndpoint, "/v1/metrics") {
-			metricExporterOpts = append(metricExporterOpts, otlpmetrichttp.WithURLPath("/v1/metrics"))
-		}
-		if cfg.APIKey != "" {
-			metricExporterOpts = append(metricExporterOpts, otlpmetrichttp.WithHeaders(map[string]string{
-				"authorization": cfg.APIKey,
-			}))
-		}
-		metricExporter, err = otlpmetrichttp.New(context.Background(), metricExporterOpts...)
+
+	switch protocol {
+	case "grpc":
+		metricExporter, err = otlpmetricgrpc.New(context.Background())
+	case "http/protobuf", "http":
+		metricExporter, err = otlpmetrichttp.New(context.Background())
 	}
-	
 	if err != nil {
 		tracerProvider.Shutdown(context.Background())
 		return nil, fmt.Errorf("failed to create metric exporter: %w", err)

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -150,6 +150,12 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 			fmt.Printf("Error starting New Relic client: %v\n", err)
 			os.Exit(1)
 		}
+	case "opentelemetry":
+		metricsBackend, err = backend.NewOpenTelemetryBackend()
+		if err != nil {
+			fmt.Printf("Error starting OpenTelemetry backend: %v\n", err)
+			os.Exit(1)
+		}
 
 	default:
 		dimensions, err := backend.ParseCloudWatchDimensions(clwDimensions)

--- a/main.go
+++ b/main.go
@@ -135,6 +135,17 @@ func main() {
 		os.Exit(1)
 	}
 
+	if closableMetrics, ok := metricsBackend.(backend.Closer); ok {
+		defer func(closer backend.Closer) {
+			err := closer.Close()
+			log.Println("Closing metrics backend")
+			if err != nil {
+				fmt.Printf("Error closing metrics backend: %v\n", err)
+				os.Exit(1)
+			}
+		}(closableMetrics)
+	}
+
 	if *quiet {
 		log.SetOutput(io.Discard)
 	}


### PR DESCRIPTION
https://github.com/buildkite/buildkite-agent-metrics/pull/412 (by @huewood) kindly added a OpenTelemetry backend. Thanks @huewood 💚 

This PR makes the code a bit simpler by delegating to the built-in (and documented) mechanism on the OpenTelemetry SDK.

See comment on PR: https://github.com/buildkite/buildkite-agent-metrics/pull/412/files#r2174197744

> this header pattern of API keys is a bit of a HyperDX specific behavior, where the "standard" OTel collector expects either Authorization: Bearer <token> or Authorization: Basic <base64 user:password).
>
> https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/bearertokenauthextension/README.md
>
> https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/basicauthextension/README.md
>
> Other vendors like [Honeycomb](https://docs.honeycomb.io/send-data/opentelemetry/#using-the-honeycomb-opentelemetry-endpoint) have again a different schema with x-honeycomb-team, [Datadog's agentess tracing](https://docs.datadoghq.com/opentelemetry/setup/agentless/traces/) uses dd-api-key and a few extra headers.
>
> I wonder if we have could have omitted this accidentally vendor-specific bit and instead used the build-in otel env vars OTEL_EXPORTER_OTLP_HEADERS to let people specify the single or multiple headers arbitrarily? Or accepted the headers as a cli flags rather than the API key?

The related otel docs are here:

https://opentelemetry.io/docs/specs/otel/protocol/exporter/#specifying-headers-via-environment-variables
https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration

This is technically a breaking change to the interface interface, but seeing as this was but we'd not yet tagged the version bump in https://github.com/buildkite/buildkite-agent-metrics/pull/414 I think we can just move forward.

This also adds two other things:

- Ensure we invoke shutdown messages when running this as a script (eg. not via lambda)
- Support `opentelemetry` backend in Lambda.