### PR TITLE
Update to use OIDC session tokens on AWS role assumption

### DIFF
--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -6,8 +6,12 @@ steps:
     concurrency: 1
     concurrency_group: "release_buildkite_metrics_github"
     plugins:
-      - aws-assume-role-with-web-identity:
+      - aws-assume-role-with-web-identity#v1.4.0:
           role-arn: arn:aws:iam::172840064832:role/pipeline-buildkite-buildkite-agent-metrics
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
 
   - label: ":github: Release"
     command: ".buildkite/steps/release-github.sh"
@@ -34,8 +38,12 @@ steps:
     agents:
       queue: "elastic-runners"
     plugins:
-      - aws-assume-role-with-web-identity:
+      - aws-assume-role-with-web-identity#v1.4.0:
           role-arn: arn:aws:iam::172840064832:role/pipeline-buildkite-buildkite-agent-metrics-release
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
       - ecr#v2.9.0:
           login: true
           account_ids: "public.ecr.aws"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -60,8 +60,12 @@ steps:
     concurrency: 1
     concurrency_group: "release_buildkite_metrics_s3"
     plugins:
-      - aws-assume-role-with-web-identity:
+      - aws-assume-role-with-web-identity#v1.4.0:
           role-arn: arn:aws:iam::172840064832:role/pipeline-buildkite-buildkite-agent-metrics
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
 
   - if: build.env("RELEASE_DRY_RUN") == "true" || build.env("BUILDKITE_TAG") =~ /^v\d+\.\d+\.\d+$$/
     block: ":rocket: Release ${BUILDKITE_TAG:-UNTAGGED}?"


### PR DESCRIPTION
Roll out using session tags for OIDC assumable IAM role trust policy.

Follow on from the work to support session tags in https://github.com/buildkite-plugins/aws-assume-role-with-web-identity-buildkite-plugin/pull/18

Requires matching update to the IAM role in PR: https://github.com/buildkite/aws-buildkite-dist/pull/130  to be shipped first