### PR TITLE
Add Grafana dashboard (for use with Prometheus backend)

### DIFF
--- a/dashboards/grafana-prometheus.json
+++ b/dashboards/grafana-prometheus.json
@@ -1,0 +1,1018 @@
+{
+  "__inputs": [
+	{
+	  "name": "DS_PROMETHEUS",
+	  "label": "Prometheus",
+	  "description": "",
+	  "type": "datasource",
+	  "pluginId": "prometheus",
+	  "pluginName": "Prometheus"
+	}
+  ],
+  "__elements": {},
+  "__requires": [
+	{
+	  "type": "panel",
+	  "id": "gauge",
+	  "name": "Gauge",
+	  "version": ""
+	},
+	{
+	  "type": "grafana",
+	  "id": "grafana",
+	  "name": "Grafana",
+	  "version": "12.2.0-16791878397"
+	},
+	{
+	  "type": "datasource",
+	  "id": "prometheus",
+	  "name": "Prometheus",
+	  "version": "1.0.0"
+	},
+	{
+	  "type": "panel",
+	  "id": "timeseries",
+	  "name": "Time series",
+	  "version": ""
+	}
+  ],
+  "annotations": {
+	"list": [
+	  {
+		"builtIn": 1,
+		"datasource": {
+		  "type": "grafana",
+		  "uid": "-- Grafana --"
+		},
+		"enable": true,
+		"hide": true,
+		"iconColor": "rgba(0, 211, 255, 1)",
+		"name": "Annotations & Alerts",
+		"type": "dashboard"
+	  }
+	]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+	{
+	  "collapsed": false,
+	  "gridPos": {
+		"h": 1,
+		"w": 24,
+		"x": 0,
+		"y": 0
+	  },
+	  "id": 3,
+	  "panels": [],
+	  "repeat": "CLUSTER",
+	  "title": "$CLUSTER cluster overview",
+	  "type": "row"
+	},
+	{
+	  "datasource": {
+		"type": "prometheus",
+		"uid": "${DS_PROMETHEUS}"
+	  },
+	  "fieldConfig": {
+		"defaults": {
+		  "color": {
+			"mode": "thresholds"
+		  },
+		  "mappings": [],
+		  "thresholds": {
+			"mode": "absolute",
+			"steps": [
+			  {
+				"color": "green",
+				"value": 0
+			  },
+			  {
+				"color": "red",
+				"value": 80
+			  }
+			]
+		  }
+		},
+		"overrides": []
+	  },
+	  "gridPos": {
+		"h": 4,
+		"w": 3,
+		"x": 0,
+		"y": 1
+	  },
+	  "id": 5,
+	  "options": {
+		"minVizHeight": 75,
+		"minVizWidth": 75,
+		"orientation": "auto",
+		"reduceOptions": {
+		  "calcs": [
+			"lastNotNull"
+		  ],
+		  "fields": "",
+		  "values": false
+		},
+		"showThresholdLabels": false,
+		"showThresholdMarkers": true,
+		"sizing": "auto"
+	  },
+	  "pluginVersion": "12.2.0-16791878397",
+	  "targets": [
+		{
+		  "datasource": {
+			"type": "prometheus",
+			"uid": "${DS_PROMETHEUS}"
+		  },
+		  "editorMode": "builder",
+		  "expr": "buildkite_total_total_agent_count{cluster=\"$CLUSTER\"}",
+		  "legendFormat": "__auto",
+		  "range": true,
+		  "refId": "A"
+		}
+	  ],
+	  "title": "Total agents",
+	  "type": "gauge"
+	},
+	{
+	  "datasource": {
+		"type": "prometheus",
+		"uid": "${DS_PROMETHEUS}"
+	  },
+	  "fieldConfig": {
+		"defaults": {
+		  "color": {
+			"mode": "thresholds"
+		  },
+		  "mappings": [],
+		  "thresholds": {
+			"mode": "absolute",
+			"steps": [
+			  {
+				"color": "orange",
+				"value": 0
+			  }
+			]
+		  }
+		},
+		"overrides": []
+	  },
+	  "gridPos": {
+		"h": 4,
+		"w": 3,
+		"x": 3,
+		"y": 1
+	  },
+	  "id": 2,
+	  "options": {
+		"minVizHeight": 75,
+		"minVizWidth": 75,
+		"orientation": "auto",
+		"reduceOptions": {
+		  "calcs": [
+			"lastNotNull"
+		  ],
+		  "fields": "",
+		  "values": false
+		},
+		"showThresholdLabels": false,
+		"showThresholdMarkers": true,
+		"sizing": "auto"
+	  },
+	  "pluginVersion": "12.2.0-16791878397",
+	  "targets": [
+		{
+		  "datasource": {
+			"type": "prometheus",
+			"uid": "${DS_PROMETHEUS}"
+		  },
+		  "editorMode": "builder",
+		  "expr": "sum(buildkite_total_busy_agent_count{cluster=\"$CLUSTER\"})",
+		  "legendFormat": "__auto",
+		  "range": true,
+		  "refId": "A"
+		}
+	  ],
+	  "title": "Busy agents",
+	  "type": "gauge"
+	},
+	{
+	  "datasource": {
+		"type": "prometheus",
+		"uid": "${DS_PROMETHEUS}"
+	  },
+	  "fieldConfig": {
+		"defaults": {
+		  "color": {
+			"mode": "thresholds"
+		  },
+		  "mappings": [],
+		  "thresholds": {
+			"mode": "absolute",
+			"steps": [
+			  {
+				"color": "blue",
+				"value": 0
+			  }
+			]
+		  }
+		},
+		"overrides": []
+	  },
+	  "gridPos": {
+		"h": 4,
+		"w": 3,
+		"x": 6,
+		"y": 1
+	  },
+	  "id": 6,
+	  "options": {
+		"minVizHeight": 75,
+		"minVizWidth": 75,
+		"orientation": "auto",
+		"reduceOptions": {
+		  "calcs": [
+			"lastNotNull"
+		  ],
+		  "fields": "",
+		  "values": false
+		},
+		"showThresholdLabels": false,
+		"showThresholdMarkers": true,
+		"sizing": "auto"
+	  },
+	  "pluginVersion": "12.2.0-16791878397",
+	  "targets": [
+		{
+		  "datasource": {
+			"type": "prometheus",
+			"uid": "${DS_PROMETHEUS}"
+		  },
+		  "editorMode": "builder",
+		  "expr": "sum(buildkite_total_idle_agent_count{cluster=\"$CLUSTER\"})",
+		  "legendFormat": "__auto",
+		  "range": true,
+		  "refId": "A"
+		}
+	  ],
+	  "title": "Idle agents",
+	  "type": "gauge"
+	},
+	{
+	  "datasource": {
+		"type": "prometheus",
+		"uid": "${DS_PROMETHEUS}"
+	  },
+	  "fieldConfig": {
+		"defaults": {
+		  "color": {
+			"mode": "thresholds"
+		  },
+		  "mappings": [],
+		  "thresholds": {
+			"mode": "absolute",
+			"steps": [
+			  {
+				"color": "blue",
+				"value": 0
+			  }
+			]
+		  }
+		},
+		"overrides": []
+	  },
+	  "gridPos": {
+		"h": 4,
+		"w": 3,
+		"x": 12,
+		"y": 1
+	  },
+	  "id": 9,
+	  "options": {
+		"minVizHeight": 75,
+		"minVizWidth": 75,
+		"orientation": "auto",
+		"reduceOptions": {
+		  "calcs": [
+			"lastNotNull"
+		  ],
+		  "fields": "",
+		  "values": false
+		},
+		"showThresholdLabels": false,
+		"showThresholdMarkers": true,
+		"sizing": "auto"
+	  },
+	  "pluginVersion": "12.2.0-16791878397",
+	  "targets": [
+		{
+		  "datasource": {
+			"type": "prometheus",
+			"uid": "${DS_PROMETHEUS}"
+		  },
+		  "editorMode": "builder",
+		  "expr": "sum(buildkite_total_scheduled_jobs_count{cluster=\"$CLUSTER\"})",
+		  "legendFormat": "__auto",
+		  "range": true,
+		  "refId": "A"
+		}
+	  ],
+	  "title": "Scheduled jobs",
+	  "type": "gauge"
+	},
+	{
+	  "datasource": {
+		"type": "prometheus",
+		"uid": "${DS_PROMETHEUS}"
+	  },
+	  "fieldConfig": {
+		"defaults": {
+		  "color": {
+			"mode": "thresholds"
+		  },
+		  "mappings": [],
+		  "thresholds": {
+			"mode": "absolute",
+			"steps": [
+			  {
+				"color": "text",
+				"value": 0
+			  }
+			]
+		  }
+		},
+		"overrides": []
+	  },
+	  "gridPos": {
+		"h": 4,
+		"w": 3,
+		"x": 15,
+		"y": 1
+	  },
+	  "id": 10,
+	  "options": {
+		"minVizHeight": 75,
+		"minVizWidth": 75,
+		"orientation": "auto",
+		"reduceOptions": {
+		  "calcs": [
+			"lastNotNull"
+		  ],
+		  "fields": "",
+		  "values": false
+		},
+		"showThresholdLabels": false,
+		"showThresholdMarkers": true,
+		"sizing": "auto"
+	  },
+	  "pluginVersion": "12.2.0-16791878397",
+	  "targets": [
+		{
+		  "datasource": {
+			"type": "prometheus",
+			"uid": "${DS_PROMETHEUS}"
+		  },
+		  "editorMode": "builder",
+		  "expr": "sum(buildkite_total_waiting_jobs_count{cluster=\"$CLUSTER\"})",
+		  "legendFormat": "__auto",
+		  "range": true,
+		  "refId": "A"
+		}
+	  ],
+	  "title": "Waiting jobs",
+	  "type": "gauge"
+	},
+	{
+	  "datasource": {
+		"type": "prometheus",
+		"uid": "${DS_PROMETHEUS}"
+	  },
+	  "fieldConfig": {
+		"defaults": {
+		  "color": {
+			"mode": "thresholds"
+		  },
+		  "mappings": [],
+		  "thresholds": {
+			"mode": "absolute",
+			"steps": [
+			  {
+				"color": "orange",
+				"value": 0
+			  }
+			]
+		  }
+		},
+		"overrides": []
+	  },
+	  "gridPos": {
+		"h": 4,
+		"w": 3,
+		"x": 18,
+		"y": 1
+	  },
+	  "id": 11,
+	  "options": {
+		"minVizHeight": 75,
+		"minVizWidth": 75,
+		"orientation": "auto",
+		"reduceOptions": {
+		  "calcs": [
+			"lastNotNull"
+		  ],
+		  "fields": "",
+		  "values": false
+		},
+		"showThresholdLabels": false,
+		"showThresholdMarkers": true,
+		"sizing": "auto"
+	  },
+	  "pluginVersion": "12.2.0-16791878397",
+	  "targets": [
+		{
+		  "datasource": {
+			"type": "prometheus",
+			"uid": "${DS_PROMETHEUS}"
+		  },
+		  "editorMode": "builder",
+		  "expr": "sum(buildkite_total_running_jobs_count{cluster=\"$CLUSTER\"})",
+		  "legendFormat": "__auto",
+		  "range": true,
+		  "refId": "A"
+		}
+	  ],
+	  "title": "Running jobs",
+	  "type": "gauge"
+	},
+	{
+	  "datasource": {
+		"type": "prometheus",
+		"uid": "${DS_PROMETHEUS}"
+	  },
+	  "fieldConfig": {
+		"defaults": {
+		  "color": {
+			"mode": "thresholds"
+		  },
+		  "mappings": [],
+		  "thresholds": {
+			"mode": "absolute",
+			"steps": [
+			  {
+				"color": "green",
+				"value": 0
+			  }
+			]
+		  }
+		},
+		"overrides": []
+	  },
+	  "gridPos": {
+		"h": 4,
+		"w": 3,
+		"x": 21,
+		"y": 1
+	  },
+	  "id": 12,
+	  "options": {
+		"minVizHeight": 75,
+		"minVizWidth": 75,
+		"orientation": "auto",
+		"reduceOptions": {
+		  "calcs": [
+			"lastNotNull"
+		  ],
+		  "fields": "",
+		  "values": false
+		},
+		"showThresholdLabels": false,
+		"showThresholdMarkers": true,
+		"sizing": "auto"
+	  },
+	  "pluginVersion": "12.2.0-16791878397",
+	  "targets": [
+		{
+		  "datasource": {
+			"type": "prometheus",
+			"uid": "${DS_PROMETHEUS}"
+		  },
+		  "editorMode": "builder",
+		  "expr": "sum(buildkite_total_unfinished_jobs_count{cluster=\"$CLUSTER\"})",
+		  "legendFormat": "__auto",
+		  "range": true,
+		  "refId": "A"
+		}
+	  ],
+	  "title": "Unfinished jobs",
+	  "type": "gauge"
+	},
+	{
+	  "datasource": {
+		"type": "prometheus",
+		"uid": "${DS_PROMETHEUS}"
+	  },
+	  "fieldConfig": {
+		"defaults": {
+		  "color": {
+			"mode": "palette-classic"
+		  },
+		  "custom": {
+			"axisBorderShow": false,
+			"axisCenteredZero": false,
+			"axisColorMode": "text",
+			"axisLabel": "",
+			"axisPlacement": "auto",
+			"barAlignment": 0,
+			"barWidthFactor": 0.6,
+			"drawStyle": "bars",
+			"fillOpacity": 69,
+			"gradientMode": "opacity",
+			"hideFrom": {
+			  "legend": false,
+			  "tooltip": false,
+			  "viz": false
+			},
+			"insertNulls": false,
+			"lineInterpolation": "linear",
+			"lineWidth": 1,
+			"pointSize": 5,
+			"scaleDistribution": {
+			  "type": "linear"
+			},
+			"showPoints": "auto",
+			"spanNulls": false,
+			"stacking": {
+			  "group": "A",
+			  "mode": "normal"
+			},
+			"thresholdsStyle": {
+			  "mode": "off"
+			}
+		  },
+		  "mappings": [],
+		  "thresholds": {
+			"mode": "absolute",
+			"steps": [
+			  {
+				"color": "green",
+				"value": 0
+			  }
+			]
+		  }
+		},
+		"overrides": []
+	  },
+	  "gridPos": {
+		"h": 8,
+		"w": 12,
+		"x": 0,
+		"y": 5
+	  },
+	  "id": 1,
+	  "options": {
+		"legend": {
+		  "calcs": [],
+		  "displayMode": "list",
+		  "placement": "bottom",
+		  "showLegend": true
+		},
+		"tooltip": {
+		  "hideZeros": false,
+		  "mode": "single",
+		  "sort": "none"
+		}
+	  },
+	  "pluginVersion": "12.2.0-16791878397",
+	  "targets": [
+		{
+		  "datasource": {
+			"type": "prometheus",
+			"uid": "${DS_PROMETHEUS}"
+		  },
+		  "editorMode": "builder",
+		  "expr": "sum by(queue) (buildkite_queues_total_agent_count{cluster=\"$CLUSTER\"})",
+		  "legendFormat": "__auto",
+		  "range": true,
+		  "refId": "A"
+		}
+	  ],
+	  "title": "Agents running by queue",
+	  "type": "timeseries"
+	},
+	{
+	  "datasource": {
+		"type": "prometheus",
+		"uid": "${DS_PROMETHEUS}"
+	  },
+	  "fieldConfig": {
+		"defaults": {
+		  "color": {
+			"mode": "palette-classic"
+		  },
+		  "custom": {
+			"axisBorderShow": false,
+			"axisCenteredZero": false,
+			"axisColorMode": "text",
+			"axisLabel": "",
+			"axisPlacement": "auto",
+			"barAlignment": 0,
+			"barWidthFactor": 0.6,
+			"drawStyle": "bars",
+			"fillOpacity": 69,
+			"gradientMode": "opacity",
+			"hideFrom": {
+			  "legend": false,
+			  "tooltip": false,
+			  "viz": false
+			},
+			"insertNulls": false,
+			"lineInterpolation": "linear",
+			"lineWidth": 1,
+			"pointSize": 5,
+			"scaleDistribution": {
+			  "type": "linear"
+			},
+			"showPoints": "auto",
+			"spanNulls": false,
+			"stacking": {
+			  "group": "A",
+			  "mode": "normal"
+			},
+			"thresholdsStyle": {
+			  "mode": "off"
+			}
+		  },
+		  "mappings": [],
+		  "thresholds": {
+			"mode": "absolute",
+			"steps": [
+			  {
+				"color": "green",
+				"value": 0
+			  }
+			]
+		  }
+		},
+		"overrides": []
+	  },
+	  "gridPos": {
+		"h": 8,
+		"w": 12,
+		"x": 12,
+		"y": 5
+	  },
+	  "id": 8,
+	  "options": {
+		"legend": {
+		  "calcs": [],
+		  "displayMode": "list",
+		  "placement": "bottom",
+		  "showLegend": true
+		},
+		"tooltip": {
+		  "hideZeros": false,
+		  "mode": "single",
+		  "sort": "none"
+		}
+	  },
+	  "pluginVersion": "12.2.0-16791878397",
+	  "targets": [
+		{
+		  "datasource": {
+			"type": "prometheus",
+			"uid": "${DS_PROMETHEUS}"
+		  },
+		  "editorMode": "code",
+		  "expr": "sum by (queue) ({__name__=~\"buildkite_queues_(scheduled|waiting|running)_jobs_count\", cluster=\"$CLUSTER\"})",
+		  "legendFormat": "__auto",
+		  "range": true,
+		  "refId": "A"
+		}
+	  ],
+	  "title": "Total jobs by queue",
+	  "type": "timeseries"
+	},
+	{
+	  "collapsed": false,
+	  "gridPos": {
+		"h": 1,
+		"w": 24,
+		"x": 0,
+		"y": 26
+	  },
+	  "id": 4,
+	  "panels": [],
+	  "repeat": "QUEUE",
+	  "title": "$QUEUE queue metrics",
+	  "type": "row"
+	},
+	{
+	  "datasource": {
+		"type": "prometheus",
+		"uid": "${DS_PROMETHEUS}"
+	  },
+	  "fieldConfig": {
+		"defaults": {
+		  "color": {
+			"mode": "palette-classic"
+		  },
+		  "custom": {
+			"axisBorderShow": false,
+			"axisCenteredZero": false,
+			"axisColorMode": "text",
+			"axisLabel": "",
+			"axisPlacement": "auto",
+			"barAlignment": 0,
+			"barWidthFactor": 0.6,
+			"drawStyle": "bars",
+			"fillOpacity": 69,
+			"gradientMode": "opacity",
+			"hideFrom": {
+			  "legend": false,
+			  "tooltip": false,
+			  "viz": false
+			},
+			"insertNulls": false,
+			"lineInterpolation": "linear",
+			"lineStyle": {
+			  "fill": "solid"
+			},
+			"lineWidth": 1,
+			"pointSize": 5,
+			"scaleDistribution": {
+			  "type": "linear"
+			},
+			"showPoints": "auto",
+			"spanNulls": false,
+			"stacking": {
+			  "group": "A",
+			  "mode": "normal"
+			},
+			"thresholdsStyle": {
+			  "mode": "off"
+			}
+		  },
+		  "mappings": [],
+		  "thresholds": {
+			"mode": "absolute",
+			"steps": [
+			  {
+				"color": "green",
+				"value": 0
+			  }
+			]
+		  }
+		},
+		"overrides": []
+	  },
+	  "gridPos": {
+		"h": 8,
+		"w": 12,
+		"x": 0,
+		"y": 27
+	  },
+	  "id": 7,
+	  "options": {
+		"legend": {
+		  "calcs": [],
+		  "displayMode": "list",
+		  "placement": "bottom",
+		  "showLegend": true
+		},
+		"tooltip": {
+		  "hideZeros": false,
+		  "mode": "single",
+		  "sort": "none"
+		}
+	  },
+	  "pluginVersion": "12.2.0-16791878397",
+	  "targets": [
+		{
+		  "datasource": {
+			"type": "prometheus",
+			"uid": "${DS_PROMETHEUS}"
+		  },
+		  "editorMode": "builder",
+		  "expr": "sum(buildkite_queues_busy_agent_count{queue=\"$QUEUE\"})",
+		  "legendFormat": "Busy",
+		  "range": true,
+		  "refId": "A"
+		},
+		{
+		  "datasource": {
+			"type": "prometheus",
+			"uid": "${DS_PROMETHEUS}"
+		  },
+		  "editorMode": "builder",
+		  "expr": "sum(buildkite_queues_idle_agent_count{queue=\"$QUEUE\"})",
+		  "hide": false,
+		  "instant": false,
+		  "legendFormat": "Idle",
+		  "range": true,
+		  "refId": "B"
+		}
+	  ],
+	  "title": "Agents by state",
+	  "type": "timeseries"
+	},
+	{
+	  "datasource": {
+		"type": "prometheus",
+		"uid": "${DS_PROMETHEUS}"
+	  },
+	  "fieldConfig": {
+		"defaults": {
+		  "color": {
+			"mode": "palette-classic"
+		  },
+		  "custom": {
+			"axisBorderShow": false,
+			"axisCenteredZero": false,
+			"axisColorMode": "text",
+			"axisLabel": "",
+			"axisPlacement": "auto",
+			"barAlignment": 0,
+			"barWidthFactor": 0.6,
+			"drawStyle": "bars",
+			"fillOpacity": 69,
+			"gradientMode": "opacity",
+			"hideFrom": {
+			  "legend": false,
+			  "tooltip": false,
+			  "viz": false
+			},
+			"insertNulls": false,
+			"lineInterpolation": "linear",
+			"lineWidth": 1,
+			"pointSize": 5,
+			"scaleDistribution": {
+			  "type": "linear"
+			},
+			"showPoints": "auto",
+			"spanNulls": false,
+			"stacking": {
+			  "group": "A",
+			  "mode": "normal"
+			},
+			"thresholdsStyle": {
+			  "mode": "off"
+			}
+		  },
+		  "mappings": [],
+		  "thresholds": {
+			"mode": "absolute",
+			"steps": [
+			  {
+				"color": "green",
+				"value": 0
+			  }
+			]
+		  }
+		},
+		"overrides": []
+	  },
+	  "gridPos": {
+		"h": 8,
+		"w": 12,
+		"x": 12,
+		"y": 27
+	  },
+	  "id": 13,
+	  "options": {
+		"legend": {
+		  "calcs": [],
+		  "displayMode": "list",
+		  "placement": "bottom",
+		  "showLegend": true
+		},
+		"tooltip": {
+		  "hideZeros": false,
+		  "mode": "single",
+		  "sort": "none"
+		}
+	  },
+	  "pluginVersion": "12.2.0-16791878397",
+	  "targets": [
+		{
+		  "datasource": {
+			"type": "prometheus",
+			"uid": "${DS_PROMETHEUS}"
+		  },
+		  "editorMode": "code",
+		  "expr": "sum (buildkite_queues_waiting_jobs_count{queue=\"$QUEUE\"})",
+		  "legendFormat": "Waiting",
+		  "range": true,
+		  "refId": "A"
+		},
+		{
+		  "datasource": {
+			"type": "prometheus",
+			"uid": "${DS_PROMETHEUS}"
+		  },
+		  "editorMode": "code",
+		  "expr": "sum (buildkite_queues_scheduled_jobs_count{queue=\"$QUEUE\"})",
+		  "hide": false,
+		  "instant": false,
+		  "legendFormat": "Scheduled",
+		  "range": true,
+		  "refId": "B"
+		},
+		{
+		  "datasource": {
+			"type": "prometheus",
+			"uid": "${DS_PROMETHEUS}"
+		  },
+		  "editorMode": "code",
+		  "expr": "sum (buildkite_queues_running_jobs_count{queue=\"$QUEUE\"})",
+		  "hide": false,
+		  "instant": false,
+		  "legendFormat": "Running",
+		  "range": true,
+		  "refId": "C"
+		},
+		{
+		  "datasource": {
+			"type": "prometheus",
+			"uid": "${DS_PROMETHEUS}"
+		  },
+		  "editorMode": "code",
+		  "expr": "sum (buildkite_queues_unfinished_jobs_count{queue=\"$QUEUE\"})",
+		  "hide": true,
+		  "instant": false,
+		  "legendFormat": "Unfinished",
+		  "range": true,
+		  "refId": "D"
+		}
+	  ],
+	  "title": "Jobs by state",
+	  "type": "timeseries"
+	}
+  ],
+  "refresh": "auto",
+  "schemaVersion": 41,
+  "tags": [],
+  "templating": {
+	"list": [
+	  {
+		"allowCustomValue": false,
+		"current": {},
+		"datasource": {
+		  "type": "prometheus",
+		  "uid": "${DS_PROMETHEUS}"
+		},
+		"definition": "label_values(cluster)",
+		"description": "",
+		"includeAll": false,
+		"label": "Cluster",
+		"name": "CLUSTER",
+		"options": [],
+		"query": {
+		  "qryType": 1,
+		  "query": "label_values(cluster)",
+		  "refId": "PrometheusVariableQueryEditor-VariableQuery"
+		},
+		"refresh": 1,
+		"regex": "",
+		"type": "query"
+	  },
+	  {
+		"allowCustomValue": true,
+		"current": {},
+		"datasource": {
+		  "type": "prometheus",
+		  "uid": "${DS_PROMETHEUS}"
+		},
+		"definition": "label_values({cluster=\"$CLUSTER\"},queue)",
+		"description": "",
+		"includeAll": true,
+		"label": "Queue",
+		"multi": true,
+		"name": "QUEUE",
+		"options": [],
+		"query": {
+		  "qryType": 1,
+		  "query": "label_values({cluster=\"$CLUSTER\"},queue)",
+		  "refId": "PrometheusVariableQueryEditor-VariableQuery"
+		},
+		"refresh": 1,
+		"regex": "",
+		"sort": 1,
+		"type": "query"
+	  }
+	]
+  },
+  "time": {
+	"from": "now-1h",
+	"to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Buildkite Agent Metrics",
+  "uid": "e2eb56fd-4d19-4e09-9b06-e479bb66bb72",
+  "version": 6,
+  "weekStart": ""
+}


### PR DESCRIPTION
Add the JSON export of a Grafana dashboard that I whipped up. It is built assuming Grafana is being used with a Prometheus backend that scrapes buildkite-agent-metrics.

<img width="1567" height="901" alt="Screenshot 2025-08-11 at 3 50 00 pm" src="https://github.com/user-attachments/assets/b9be0e29-3c5a-40f4-8a3d-bf7662b5354f" />