### PR TITLE
Better HTTP errors

### DIFF
--- a/backend/stackdriver.go
+++ b/backend/stackdriver.go
@@ -40,7 +40,7 @@ func NewStackDriverBackend(gcpProjectID string) (*StackDriverBackend, error) {
 	ctx := context.Background()
 	c, err := monitoring.NewMetricClient(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("[NewStackDriverBackend] could not create stackdriver client: %v", err)
+		return nil, fmt.Errorf("[NewStackDriverBackend] could not create stackdriver client: %w", err)
 	}
 
 	return &StackDriverBackend{
@@ -68,7 +68,7 @@ func (sd *StackDriverBackend) Collect(r *collector.Result) error {
 			metricReq := createCustomMetricRequest(&sd.projectID, &mt)
 			_, err := sd.client.CreateMetricDescriptor(ctx, metricReq)
 			if err != nil {
-				retErr := fmt.Errorf("[Collect] could not create custom metric [%s]: %v", mt, err)
+				retErr := fmt.Errorf("[Collect] could not create custom metric [%s]: %w", mt, err)
 				log.Println(retErr)
 				return retErr
 			}
@@ -78,7 +78,7 @@ func (sd *StackDriverBackend) Collect(r *collector.Result) error {
 		req := createTimeSeriesValueRequest(&sd.projectID, &mt, r.Cluster, totalMetricsQueue, value, now)
 		err := sd.client.CreateTimeSeries(ctx, req)
 		if err != nil {
-			retErr := fmt.Errorf("[Collect] could not write metric [%s] value [%d], %v ", mt, value, err)
+			retErr := fmt.Errorf("[Collect] could not write metric [%s] value [%d], %w", mt, value, err)
 			log.Println(retErr)
 			return retErr
 		}
@@ -90,7 +90,7 @@ func (sd *StackDriverBackend) Collect(r *collector.Result) error {
 			req := createTimeSeriesValueRequest(&sd.projectID, &mt, r.Cluster, queue, value, now)
 			err := sd.client.CreateTimeSeries(ctx, req)
 			if err != nil {
-				retErr := fmt.Errorf("[Collect] could not write metric [%s] value [%d], %v ", mt, value, err)
+				retErr := fmt.Errorf("[Collect] could not write metric [%s] value [%d], %w ", mt, value, err)
 				log.Println(retErr)
 				return retErr
 			}

--- a/main.go
+++ b/main.go
@@ -191,8 +191,10 @@ func main() {
 		for _, c := range collectors {
 			result, err := c.Collect()
 			if err != nil {
-				fmt.Printf("Error collecting agent metrics, err: %s\n", err)
-				if errors.Is(err, collector.ErrUnauthorized) {
+				fmt.Println("Error collecting agent metrics:", err)
+
+				var httpErr collector.HTTPError
+				if errors.As(err, &httpErr) && httpErr.StatusCode == 401 {
 					// Unique exit code to signal HTTP 401
 					os.Exit(4)
 				}

--- a/token/secretsmanager.go
+++ b/token/secretsmanager.go
@@ -59,12 +59,12 @@ func (p secretsManagerProvider) Get() (string, error) {
 	})
 
 	if err != nil {
-		return "", fmt.Errorf("failed to retrieve secret '%s' from SecretsManager: %v", p.SecretID, err)
+		return "", fmt.Errorf("failed to retrieve secret '%s' from SecretsManager: %w", p.SecretID, err)
 	}
 
 	secret, err := p.parseResponse(res)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse SecretsManager's response for '%s': %v", p.SecretID, err)
+		return "", fmt.Errorf("failed to parse SecretsManager's response for '%s': %w", p.SecretID, err)
 	}
 
 	return secret, nil

--- a/token/ssm.go
+++ b/token/ssm.go
@@ -45,7 +45,7 @@ func (p ssmProvider) Get() (string, error) {
 	})
 
 	if err != nil {
-		return "", fmt.Errorf("failed to retrieve Buildkite token (%s) from AWS SSM: %v", p.Name, err)
+		return "", fmt.Errorf("failed to retrieve Buildkite token (%s) from AWS SSM: %w", p.Name, err)
 	}
 
 	return *output.Parameter.Value, nil


### PR DESCRIPTION
In https://github.com/buildkite/buildkite-agent-metrics/issues/447, @trfullhart-benchling reported that HTTP 401 responses don't report the message that buildkite returns back with the response body.

This PR fixes that, and generally makes the HTTP error handling a little more consistent and reasonable. It also replaces a bunch of `fmt.Errorf("... %v")` with `fmt.Errorf("... %w")`, which will properly wrap errors as they should be wrapped.

Closes #447 