### PR TITLE
Remove redundant queue scope

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -65,8 +65,6 @@ steps:
       - build-lambda
     command: ".buildkite/steps/upload-to-s3.sh"
     branches: main
-    agents:
-      queue: "elastic-runners"
     concurrency: 1
     concurrency_group: "release_buildkite_metrics_s3"
     plugins:


### PR DESCRIPTION
The default queue for the Main cluster is the `elastic-runners` queue anyway. But the real motivator for the removal is that we're looking at moving this pipeline to use the OSS cluster, which has a different set of queues. The default queue is expected to be fine on the OSS cluster, which means we can just do away with the queue scope entirely and rely on cluster defaults.

This helps us toward getting the pipeline more aligned with our [documented strategy regarding which pipelines should go in which clusters](https://www.notion.so/buildkite/Continuous-Integration-1d6b8dbc2c898088aee6c1201478ae35?source=copy_link#1dfb8dbc2c8980d7964be5ff75d29e7d).

## Deployment

Should be a functional no-op, making it safe to merge any time.

## Revert

Safe for any time.