### PR TITLE
Remove hardcoded RELEASE_DRY_RUN

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,3 @@
-env:
-  RELEASE_DRY_RUN: false
-
 steps:
   - name: ":go::robot_face: Lint"
     key: check-code-committed


### PR DESCRIPTION
Hardcoding here means that nothing can override it, which somewhat defeats the purpose of having the environment variable in the first place. Order of precedence from the [docs](https://buildkite.com/docs/pipelines/configure/environment-variables#environment-variable-precedence), where values in each successive set take precedence:

> Pipeline, Build, Step, Standard

"Step" is pipeline.yml. "Build" is creating a build via the web UI, which is where we'd like to be able to set `RELEASE_DRY_RUN=true` on occasion