### PR TITLE
chore: Go 1.25 in go.mod, go fix ./...

### DIFF
--- a/backend/cloudwatch.go
+++ b/backend/cloudwatch.go
@@ -24,7 +24,7 @@ func ParseCloudWatchDimensions(ds string) ([]CloudWatchDimension, error) {
 		return dimensions, nil
 	}
 
-	for _, dimension := range strings.Split(strings.TrimSpace(ds), ",") {
+	for dimension := range strings.SplitSeq(strings.TrimSpace(ds), ",") {
 		parts := strings.SplitN(strings.TrimSpace(dimension), "=", 2)
 		if len(parts) != 2 {
 			return nil, fmt.Errorf("failed to parse dimension of %q", dimension)
@@ -152,10 +152,7 @@ func (cb *CloudWatchBackend) cloudwatchMetrics(counts map[string]int, dimensions
 func chunkCloudwatchMetrics(size int, data []*cloudwatch.MetricDatum) [][]*cloudwatch.MetricDatum {
 	var chunks = [][]*cloudwatch.MetricDatum{}
 	for i := 0; i < len(data); i += size {
-		end := i + size
-		if end > len(data) {
-			end = len(data)
-		}
+		end := min(i+size, len(data))
 		chunks = append(chunks, data[i:end])
 	}
 	return chunks

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildkite/buildkite-agent-metrics/v5
 
-go 1.24.0
+go 1.25.0
 
 tool go.uber.org/mock/mockgen
 

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -214,8 +214,8 @@ func initTokenProvider(awsRegion string) ([]token.Provider, error) {
 
 	var providers []token.Provider
 	if bkTokenEnvVar := os.Getenv(BKAgentTokenEnvVar); bkTokenEnvVar != "" {
-		bkTokens := strings.Split(bkTokenEnvVar, ",")
-		for _, bkToken := range bkTokens {
+		bkTokens := strings.SplitSeq(bkTokenEnvVar, ",")
+		for bkToken := range bkTokens {
 			provider, err := token.NewInMemory(bkToken)
 			if err != nil {
 				return nil, err
@@ -230,8 +230,8 @@ func initTokenProvider(awsRegion string) ([]token.Provider, error) {
 			return nil, err
 		}
 		client := ssm.New(sess)
-		ssmKeys := strings.Split(ssmKeyEnvVar, ",")
-		for _, ssmKey := range ssmKeys {
+		ssmKeys := strings.SplitSeq(ssmKeyEnvVar, ",")
+		for ssmKey := range ssmKeys {
 			ssmProvider, err := token.NewSSM(client, ssmKey)
 			if err != nil {
 				return nil, err
@@ -248,8 +248,8 @@ func initTokenProvider(awsRegion string) ([]token.Provider, error) {
 		}
 		client := secretsmanager.New(sess)
 		if jsonKey == "" {
-			secretIDs := strings.Split(secretsManagerSecretID, ",")
-			for _, secretID := range secretIDs {
+			secretIDs := strings.SplitSeq(secretsManagerSecretID, ",")
+			for secretID := range secretIDs {
 				secretManager, err := token.NewSecretsManager(client, secretID)
 				if err != nil {
 					return nil, err

--- a/main.go
+++ b/main.go
@@ -63,8 +63,8 @@ func main() {
 	}
 
 	if len(tokens) == 0 {
-		envTokens := strings.Split(os.Getenv("BUILDKITE_AGENT_TOKEN"), ",")
-		for _, t := range envTokens {
+		envTokens := strings.SplitSeq(os.Getenv("BUILDKITE_AGENT_TOKEN"), ",")
+		for t := range envTokens {
 			t = strings.TrimSpace(t)
 			if t == "" {
 				continue

--- a/token/secretsmanager.go
+++ b/token/secretsmanager.go
@@ -95,7 +95,7 @@ func (p secretsManagerProvider) parseResponse(res *secretsmanager.GetSecretValue
 }
 
 func extractStringKeyFromJSON(data []byte, key string) (string, error) {
-	contents := map[string]interface{}{}
+	contents := map[string]any{}
 	err := json.Unmarshal(data, &contents)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Go 1.24 is out of support, so specify Go 1.25 in go.mod. (Already using Go 1.25 container images in the dockerfiles.)

Then I ran `go mod tidy` and `go fix ./...`.