### PR TITLE
Update version + changelog for v5.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v5.12.1](https://github.com/buildkite/buildkite-agent-metrics/tree/v5.12.1) (2026-04-24)
+[Full Changelog](https://github.com/buildkite/buildkite-agent-metrics/compare/v5.12.0...v5.12.1)
+
+### Changed
+- chore: migrate to aws-go-sdk v2 [#517](https://github.com/buildkite/buildkite-agent-metrics/pull/517) (@buildkate)
+- build(deps): bump the container-images group across 2 directories with 3 updates [#506](https://github.com/buildkite/buildkite-agent-metrics/pull/506) (@dependabot[bot])
+- build(deps): bump the container-images group across 2 directories with 2 updates [#503](https://github.com/buildkite/buildkite-agent-metrics/pull/503) (@dependabot[bot])
+
 ## [v5.12.0](https://github.com/buildkite/buildkite-agent-metrics/tree/v5.12.0) (2026-02-13)
 [Full Changelog](https://github.com/buildkite/buildkite-agent-metrics/compare/v5.11.0...v5.12.0)
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version number.
-const Version = "5.12.0"
+const Version = "5.12.1"


### PR DESCRIPTION
## [v5.12.1](https://github.com/buildkite/buildkite-agent-metrics/tree/v5.12.1) (2026-04-24)
[Full Changelog](https://github.com/buildkite/buildkite-agent-metrics/compare/v5.12.0...v5.12.1)

### Changed
- chore: migrate to aws-go-sdk v2 [#517](https://github.com/buildkite/buildkite-agent-metrics/pull/517) (@buildkate)
- build(deps): bump the container-images group across 2 directories with 3 updates [#506](https://github.com/buildkite/buildkite-agent-metrics/pull/506) (@dependabot[bot])