### PR TITLE
fix: set AWS_DEFAULT_REGION on release pipeline

### DIFF
--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -1,3 +1,5 @@
+env:
+  AWS_DEFAULT_REGION=us-east-1
 steps:
   - label: ":s3: Upload"
     command: ".buildkite/steps/release-s3-version.sh"

--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -1,5 +1,5 @@
 env:
-  AWS_DEFAULT_REGION=us-east-1
+  AWS_DEFAULT_REGION: us-east-1
 steps:
   - label: ":s3: Upload"
     command: ".buildkite/steps/release-s3-version.sh"


### PR DESCRIPTION
Set  `AWS_DEFAULT_REGION` env on the release pipeline. Required as part of the move to the `hosted` queue