### PR TITLE
fix: zip cloud function

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -77,6 +77,11 @@ steps:
     depends_on:
       - test
     command: ".buildkite/steps/build-cloud-function.sh"
+    plugins:
+      - docker-compose#v5.5.0:
+          config: .buildkite/docker-compose.yaml
+          cli-version: 2
+          run: build
     artifact_paths:
       - ./dist/*
 

--- a/.buildkite/steps/build-cloud-function.sh
+++ b/.buildkite/steps/build-cloud-function.sh
@@ -1,8 +1,8 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 set -eu
 
 # Create a zip file containing just the code required for the cloud function
 
 mkdir -p dist
 rm -f dist/buildkite-agent-metrics.zip
-tar -a -cf dist/buildkite-agent-metrics.zip cloud_function/{main.go,go.mod,go.sum}
+( cd cloud_function && zip ../dist/buildkite-agent-metrics.zip main.go go.mod go.sum )


### PR DESCRIPTION
## Summary
- Fix cloud function source artifact being published as a tar archive instead of a real zip, which Cloud Build's gcs-fetcher rejects (blocks `elastic-ci-stack-for-gcp` deploys with autoscaling).
- Root cause: `tar -a -cf foo.zip ...` — GNU tar ignores `-a` and the `.zip` extension, producing a tar with files nested under `cloud_function/`. Replaced with `zip` run from inside `cloud_function/` so `main.go`, `go.mod`, `go.sum` land at the archive root where Cloud Functions Gen 2 expects them.


Fixes [A-1239](https://linear.app/buildkite/issue/A-1239).