### PR TITLE
Use gauges for OpenTelemetry metrics, add test coverage

### DIFF
--- a/backend/opentelemetry.go
+++ b/backend/opentelemetry.go
@@ -132,8 +132,8 @@ func NewOpenTelemetryBackend() (*OpenTelemetryBackend, error) {
 	}
 
 	backend, err := newOpenTelemetryBackend(
-		otel.Meter("buildkite-agent-metrics"),
 		otel.Tracer("buildkite-agent-metrics"),
+		otel.Meter("buildkite-agent-metrics"),
 	)
 	if err != nil {
 		otelShutdown()
@@ -145,10 +145,10 @@ func NewOpenTelemetryBackend() (*OpenTelemetryBackend, error) {
 	return backend, nil
 }
 
-// newOpenTelemetryBackend builds a backend around the given meter and tracer and
+// newOpenTelemetryBackend builds a backend around the given tracer and meter and
 // registers its instruments. Split out from NewOpenTelemetryBackend so tests can
 // supply an in-memory meter.
-func newOpenTelemetryBackend(meter metric.Meter, tracer trace.Tracer) (*OpenTelemetryBackend, error) {
+func newOpenTelemetryBackend(tracer trace.Tracer, meter metric.Meter) (*OpenTelemetryBackend, error) {
 	backend := &OpenTelemetryBackend{
 		tracer: tracer,
 		meter:  meter,

--- a/backend/opentelemetry.go
+++ b/backend/opentelemetry.go
@@ -29,10 +29,10 @@ type OpenTelemetryBackend struct {
 	meter  metric.Meter
 
 	// Metrics instruments
-	scheduledJobsCounter  metric.Int64Counter
-	runningJobsCounter    metric.Int64Counter
-	unfinishedJobsCounter metric.Int64Counter
-	waitingJobsCounter    metric.Int64Counter
+	scheduledJobsGauge    metric.Int64Gauge
+	runningJobsGauge      metric.Int64Gauge
+	unfinishedJobsGauge   metric.Int64Gauge
+	waitingJobsGauge      metric.Int64Gauge
 	idleAgentsGauge       metric.Int64Gauge
 	busyAgentsGauge       metric.Int64Gauge
 	totalAgentsGauge      metric.Int64Gauge
@@ -131,26 +131,38 @@ func NewOpenTelemetryBackend() (*OpenTelemetryBackend, error) {
 		}
 	}
 
-	backend := &OpenTelemetryBackend{
-		tracer:   otel.Tracer("buildkite-agent-metrics"),
-		meter:    otel.Meter("buildkite-agent-metrics"),
-		shutdown: otelShutdown,
-	}
-
-	// Initialize metrics instruments
-	if err := backend.initializeMetrics(); err != nil {
+	backend, err := newOpenTelemetryBackend(
+		otel.Meter("buildkite-agent-metrics"),
+		otel.Tracer("buildkite-agent-metrics"),
+	)
+	if err != nil {
 		otelShutdown()
-		return nil, fmt.Errorf("error initializing metrics: %w", err)
+		return nil, err
 	}
+	backend.shutdown = otelShutdown
 
 	log.Println("OpenTelemetry backend initialized successfully")
+	return backend, nil
+}
+
+// newOpenTelemetryBackend builds a backend around the given meter and tracer and
+// registers its instruments. Split out from NewOpenTelemetryBackend so tests can
+// supply an in-memory meter.
+func newOpenTelemetryBackend(meter metric.Meter, tracer trace.Tracer) (*OpenTelemetryBackend, error) {
+	backend := &OpenTelemetryBackend{
+		tracer: tracer,
+		meter:  meter,
+	}
+	if err := backend.initializeMetrics(); err != nil {
+		return nil, fmt.Errorf("error initializing metrics: %w", err)
+	}
 	return backend, nil
 }
 
 func (b *OpenTelemetryBackend) initializeMetrics() error {
 	var err error
 
-	b.scheduledJobsCounter, err = b.meter.Int64Counter(
+	b.scheduledJobsGauge, err = b.meter.Int64Gauge(
 		"buildkite.jobs.scheduled",
 		metric.WithDescription("Number of scheduled jobs"),
 	)
@@ -158,7 +170,7 @@ func (b *OpenTelemetryBackend) initializeMetrics() error {
 		return err
 	}
 
-	b.runningJobsCounter, err = b.meter.Int64Counter(
+	b.runningJobsGauge, err = b.meter.Int64Gauge(
 		"buildkite.jobs.running",
 		metric.WithDescription("Number of running jobs"),
 	)
@@ -166,7 +178,7 @@ func (b *OpenTelemetryBackend) initializeMetrics() error {
 		return err
 	}
 
-	b.unfinishedJobsCounter, err = b.meter.Int64Counter(
+	b.unfinishedJobsGauge, err = b.meter.Int64Gauge(
 		"buildkite.jobs.unfinished",
 		metric.WithDescription("Number of unfinished jobs"),
 	)
@@ -174,7 +186,7 @@ func (b *OpenTelemetryBackend) initializeMetrics() error {
 		return err
 	}
 
-	b.waitingJobsCounter, err = b.meter.Int64Counter(
+	b.waitingJobsGauge, err = b.meter.Int64Gauge(
 		"buildkite.jobs.waiting",
 		metric.WithDescription("Number of waiting jobs"),
 	)
@@ -249,16 +261,16 @@ func (b *OpenTelemetryBackend) Collect(r *collector.Result) error {
 
 	// Record total metrics
 	if val, ok := r.Totals["ScheduledJobsCount"]; ok {
-		b.scheduledJobsCounter.Add(ctx, int64(val), metric.WithAttributes(commonAttrs...))
+		b.scheduledJobsGauge.Record(ctx, int64(val), metric.WithAttributes(commonAttrs...))
 	}
 	if val, ok := r.Totals["RunningJobsCount"]; ok {
-		b.runningJobsCounter.Add(ctx, int64(val), metric.WithAttributes(commonAttrs...))
+		b.runningJobsGauge.Record(ctx, int64(val), metric.WithAttributes(commonAttrs...))
 	}
 	if val, ok := r.Totals["UnfinishedJobsCount"]; ok {
-		b.unfinishedJobsCounter.Add(ctx, int64(val), metric.WithAttributes(commonAttrs...))
+		b.unfinishedJobsGauge.Record(ctx, int64(val), metric.WithAttributes(commonAttrs...))
 	}
 	if val, ok := r.Totals["WaitingJobsCount"]; ok {
-		b.waitingJobsCounter.Add(ctx, int64(val), metric.WithAttributes(commonAttrs...))
+		b.waitingJobsGauge.Record(ctx, int64(val), metric.WithAttributes(commonAttrs...))
 	}
 	if val, ok := r.Totals["IdleAgentCount"]; ok {
 		b.idleAgentsGauge.Record(ctx, int64(val), metric.WithAttributes(commonAttrs...))
@@ -291,19 +303,19 @@ func (b *OpenTelemetryBackend) Collect(r *collector.Result) error {
 
 		if val, ok := queueMetrics["ScheduledJobsCount"]; ok {
 			scheduledJobs = int64(val)
-			b.scheduledJobsCounter.Add(ctx, scheduledJobs, metric.WithAttributes(queueAttrs...))
+			b.scheduledJobsGauge.Record(ctx, scheduledJobs, metric.WithAttributes(queueAttrs...))
 		}
 		if val, ok := queueMetrics["RunningJobsCount"]; ok {
 			runningJobs = int64(val)
-			b.runningJobsCounter.Add(ctx, runningJobs, metric.WithAttributes(queueAttrs...))
+			b.runningJobsGauge.Record(ctx, runningJobs, metric.WithAttributes(queueAttrs...))
 		}
 		if val, ok := queueMetrics["UnfinishedJobsCount"]; ok {
 			unfinishedJobs = int64(val)
-			b.unfinishedJobsCounter.Add(ctx, unfinishedJobs, metric.WithAttributes(queueAttrs...))
+			b.unfinishedJobsGauge.Record(ctx, unfinishedJobs, metric.WithAttributes(queueAttrs...))
 		}
 		if val, ok := queueMetrics["WaitingJobsCount"]; ok {
 			waitingJobs = int64(val)
-			b.waitingJobsCounter.Add(ctx, waitingJobs, metric.WithAttributes(queueAttrs...))
+			b.waitingJobsGauge.Record(ctx, waitingJobs, metric.WithAttributes(queueAttrs...))
 		}
 		if val, ok := queueMetrics["IdleAgentCount"]; ok {
 			idleAgents = int64(val)

--- a/backend/opentelemetry_test.go
+++ b/backend/opentelemetry_test.go
@@ -19,7 +19,7 @@ func newTestOTelBackend(t *testing.T) (*OpenTelemetryBackend, *sdkmetric.ManualR
 	reader := sdkmetric.NewManualReader()
 	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 
-	b, err := newOpenTelemetryBackend(provider.Meter("test"), noop.NewTracerProvider().Tracer("test"))
+	b, err := newOpenTelemetryBackend(noop.NewTracerProvider().Tracer("test"), provider.Meter("test"))
 	if err != nil {
 		t.Fatalf("newOpenTelemetryBackend() = %v", err)
 	}

--- a/backend/opentelemetry_test.go
+++ b/backend/opentelemetry_test.go
@@ -1,0 +1,160 @@
+package backend
+
+import (
+	"context"
+	"testing"
+
+	"github.com/buildkite/buildkite-agent-metrics/v5/collector"
+	"github.com/google/go-cmp/cmp"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+// newTestOTelBackend builds an OpenTelemetry backend wired to an in-memory
+// manual reader so tests can inspect the exported metric data.
+func newTestOTelBackend(t *testing.T) (*OpenTelemetryBackend, *sdkmetric.ManualReader) {
+	t.Helper()
+
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	b, err := newOpenTelemetryBackend(provider.Meter("test"), noop.NewTracerProvider().Tracer("test"))
+	if err != nil {
+		t.Fatalf("newOpenTelemetryBackend() = %v", err)
+	}
+	return b, reader
+}
+
+// collectMetric gathers all exported metrics and returns the one named name.
+func collectMetric(t *testing.T, reader *sdkmetric.ManualReader, name string) metricdata.Metrics {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("reader.Collect() = %v", err)
+	}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == name {
+				return m
+			}
+		}
+	}
+	t.Fatalf("metric %q not found in exported metrics", name)
+	return metricdata.Metrics{}
+}
+
+type otelPoint struct {
+	Attributes map[string]string
+	Value      int64
+}
+
+// gaugePoints returns the int64 gauge data points of the named metric, keyed by
+// the value of their "queue" attribute ("" for the cluster-total series). It
+// fails the test if the metric is not an Int64 gauge, which is the regression
+// guard for issue #541: counter instruments export as metricdata.Sum instead.
+func gaugePoints(t *testing.T, reader *sdkmetric.ManualReader, name string) map[string]otelPoint {
+	t.Helper()
+
+	m := collectMetric(t, reader, name)
+	gauge, ok := m.Data.(metricdata.Gauge[int64])
+	if !ok {
+		t.Fatalf("metric %q has data type %T, want metricdata.Gauge[int64]", name, m.Data)
+	}
+
+	points := make(map[string]otelPoint, len(gauge.DataPoints))
+	for _, dp := range gauge.DataPoints {
+		attrs := make(map[string]string)
+		for _, kv := range dp.Attributes.ToSlice() {
+			attrs[string(kv.Key)] = kv.Value.AsString()
+		}
+		points[attrs["queue"]] = otelPoint{Attributes: attrs, Value: dp.Value}
+	}
+	return points
+}
+
+// gauges maps each exported metric name to the collector key it is recorded
+// from. All eight are point-in-time gauges.
+var gauges = map[string]string{
+	"buildkite.jobs.scheduled":         collector.ScheduledJobsCount,
+	"buildkite.jobs.running":           collector.RunningJobsCount,
+	"buildkite.jobs.unfinished":        collector.UnfinishedJobsCount,
+	"buildkite.jobs.waiting":           collector.WaitingJobsCount,
+	"buildkite.agents.idle":            collector.IdleAgentCount,
+	"buildkite.agents.busy":            collector.BusyAgentCount,
+	"buildkite.agents.total":           collector.TotalAgentCount,
+	"buildkite.agents.busy_percentage": collector.BusyAgentPercentage,
+}
+
+// TestOpenTelemetryCollect drives Collect end to end against an in-memory reader
+// and checks that every metric is exported as an Int64 gauge with the expected
+// value and attributes for the cluster total and each queue.
+func TestOpenTelemetryCollect(t *testing.T) {
+	b, reader := newTestOTelBackend(t)
+	if err := b.Collect(newTestResult(t)); err != nil {
+		t.Fatalf("Collect() = %v", err)
+	}
+
+	for name, key := range gauges {
+		t.Run(name, func(t *testing.T) {
+			want := map[string]otelPoint{
+				"": {
+					Attributes: map[string]string{"org": "", "cluster": "test_cluster"},
+					Value:      int64(fakeTotals[key]),
+				},
+				"default": {
+					Attributes: map[string]string{"org": "", "cluster": "test_cluster", "queue": "default"},
+					Value:      int64(fakeDefaultQueue[key]),
+				},
+				"deploy": {
+					Attributes: map[string]string{"org": "", "cluster": "test_cluster", "queue": "deploy"},
+					Value:      int64(fakeDeployQueue[key]),
+				},
+			}
+
+			got := gaugePoints(t, reader, name)
+			if diff := cmp.Diff(got, want); diff != "" {
+				t.Errorf("%s data points diff (-got +want):\n%s", name, diff)
+			}
+		})
+	}
+}
+
+// TestOpenTelemetryJobMetricsUseLastValue records each job metric across two
+// collection intervals and asserts the exported value is the most recent one,
+// not the sum of both. A counter instrument would accumulate; a gauge does not.
+// Regression test for issue #541.
+func TestOpenTelemetryJobMetricsUseLastValue(t *testing.T) {
+	jobMetrics := []string{
+		"buildkite.jobs.scheduled",
+		"buildkite.jobs.running",
+		"buildkite.jobs.unfinished",
+		"buildkite.jobs.waiting",
+	}
+
+	for _, name := range jobMetrics {
+		t.Run(name, func(t *testing.T) {
+			b, reader := newTestOTelBackend(t)
+			key := gauges[name]
+
+			for _, v := range []int{5, 3} {
+				r := &collector.Result{
+					Cluster: "test_cluster",
+					Totals:  map[string]int{key: v},
+				}
+				if err := b.Collect(r); err != nil {
+					t.Fatalf("Collect() = %v", err)
+				}
+			}
+
+			points := gaugePoints(t, reader, name)
+			if len(points) != 1 {
+				t.Fatalf("len(points) = %d, want 1", len(points))
+			}
+			if got, want := points[""].Value, int64(3); got != want {
+				t.Errorf("%s = %d, want %d (last value, not accumulated)", name, got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The OpenTelemetry backend published the four `buildkite.jobs.*` metrics (`scheduled`, `running`, `unfinished`, `waiting`) as `Int64Counter` instruments recorded with `Add()`. A counter accumulates a monotonic sum across collection cycles, so each cycle added the current job count to a running total and the exported series only ever climbed. Backends that treat OTLP counters as cumulative sums (Honeycomb, for one) showed meaningless ever-increasing values instead of the number of jobs in each state.

This switches the four instruments to `Int64Gauge`/`Record()`, which is last-value and non-monotonic. That matches the agent metrics already in this backend, and the point-in-time semantics every other backend uses (Prometheus, Stackdriver, StatsD, CloudWatch, New Relic).

## Changes

- Switch the four job-count instruments from `Int64Counter` to `Int64Gauge`, recording with `Record()` instead of `Add()`.
- Extract `newOpenTelemetryBackend(meter, tracer)` from the public constructor so tests can inject an in-memory meter.
- Add `backend/opentelemetry_test.go`: an end-to-end `Collect` test asserting instrument type, attributes, and values for the cluster total and per-queue series, plus a last-value regression test for the job metrics. Reuses the shared fixtures from the Prometheus backend test.
- Check the error returns from the tracer/meter provider `Shutdown` calls (golangci-lint).

## Why gauges

Job counts rise and fall over time, so they are point-in-time values, not running totals. Gauge (rather than `UpDownCounter`) is correct because the code records absolute values, not deltas.

This is not a regression. The metrics have been counters since the OpenTelemetry backend was first added (PR #412, shipped in v5.10.0), so every release with this backend is affected.

## Compatibility

Metric names and descriptions are unchanged; only the OTLP instrument kind changes (Sum to Gauge). Any dashboards or queries that applied counter or `rate()` logic to these four metrics will need updating to read them as gauges.

## Testing

- `go build ./...`, `go vet ./backend/`, and `go test ./...` all pass.
- Confirmed the new tests fail against the old `Int64Counter` implementation (the metrics export as `metricdata.Sum[int64]`) and pass against the gauge fix.

Fixes #541
